### PR TITLE
ci(gh-actions): Switch to `macos-14`; prequal to #42

### DIFF
--- a/lib/mk-gh-actions-matrix.nix
+++ b/lib/mk-gh-actions-matrix.nix
@@ -5,11 +5,12 @@
 }: {
   flake = {
     lib = rec {
+      # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
       nixSystemToGHPlatform = {
-        "ubuntu-latest" = "x86_64-linux";
-        "macos-latest" = "x86_64-darwin";
-        # not supported:
-        # "macos-latest-xlarge" = "aarch64-darwin";
+        "x86_64-linux" = "ubuntu-latest";
+        # "x86_64-darwin" = "macos-13"; - macos-13 is a 4 x86_64 vCPU / 14GB RAM
+        "x86_64-darwin" = "macos-14"; # - macos-14 is a 3 aarch64 vCPU / 7GB RAM (but it seems faster than the macos-13 one)
+        "aarch64-darwin" = "macos-14";
       };
 
       inherit (import ./build-status.nix {inherit lib;}) getBuildStatus;
@@ -18,8 +19,8 @@
         include = lib.pipe (builtins.attrNames nixSystemToGHPlatform) [
           (builtins.concatMap
             (
-              platform: let
-                system = nixSystemToGHPlatform.${platform};
+              system: let
+                platform = nixSystemToGHPlatform.${system};
               in
                 map (package: let
                   p = self.packages.${system}.${package};

--- a/lib/version-catalog.nix
+++ b/lib/version-catalog.nix
@@ -10,6 +10,12 @@
   darwinPkgs = {
     inherit (pkgs.darwin.apple_sdk.frameworks) Foundation;
   };
+
+  system = pkgs.hostPlatform.system;
+  filterBySystem = pkgs:
+    lib.filterAttrs
+    (_name: pkg: builtins.elem system pkg.meta.platforms)
+    pkgs;
 in {
   genPkgVersions = pkgName: let
     mod = ../pkgs/${pkgName}/version-catalog.nix;
@@ -47,6 +53,7 @@ in {
           )
         )
         listToAttrs
+        filterBySystem
       ];
 
     hierarchical = {
@@ -58,6 +65,7 @@ in {
             supportedVersions."${type}"
           )))
         listToAttrs
+        filterBySystem
       ];
     };
   };

--- a/pkgs/ldc/binary.nix
+++ b/pkgs/ldc/binary.nix
@@ -31,6 +31,13 @@
     "i686-windows" = "windows-x86";
   };
 
+  defaultSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+  supportedSystems = lib.pipe (builtins.attrNames systemToArchivePlatform) [
+    (builtins.filter (x: builtins.elem x defaultSystems))
+    (builtins.filter (sys: hashes.${systemToArchivePlatform.${sys}} != null))
+  ];
+
   tarballSuffix =
     if hostPlatform.isWindows
     then "7z"
@@ -43,7 +50,7 @@ in
     inherit version;
 
     passthru = {
-      inherit buildStatus;
+      inherit buildStatus supportedSystems hashes;
     };
 
     src = fetchurl rec {
@@ -75,8 +82,6 @@ in
       # from https://github.com/ldc-developers/ldc/blob/master/LICENSE
       license = with licenses; [bsd3 boost mit ncsa gpl2Plus];
       maintainers = with maintainers; [ThomasMader lionello];
-      # FIXME: change to the following after the CI verifies it:
-      # platforms = builtins.attrNames systemToArchivePlatform;
-      platforms = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+      platforms = supportedSystems;
     };
   }

--- a/pkgs/ldc/build-status.json
+++ b/pkgs/ldc/build-status.json
@@ -9,6 +9,11 @@
       "build": false,
       "check": false,
       "skippedTests": []
+    },
+    "aarch64-darwin": {
+      "build": false,
+      "check": false,
+      "skippedTests": []
     }
   }
 }


### PR DESCRIPTION
- fix(pkgs/ldc/binary): Set `meta.platforms` based on the available hashes in `supported-binary-versions.json`
- improve(lib/version-catalog): Filter packages based on their supported platforms
- fix(pkgs/ldc): Allow to fail on `aarch64-darwin` as well
- ci(gh-actions): Switch to macos-14 GH-hosted runners
