### PR TITLE
Noted the difference of Nixpkgs fetching in flake world.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ You can find the full example in [`templates/devshell/`](./templates/devshell/).
 
 ### Pre-flakes usage
 
-The `default.nix` file in the root of this repo exposes all flake outputs as
-Nix attributes. This is useful for users who haven't yet made the jump to the
-Nix Flakes world.
+The `default.nix` file in the root of this repo is a
+[shim](https://nixos.wiki/wiki/Flakes#Using_flakes_with_stable_Nix) that
+exposes all flake outputs as Nix attributes. This is useful for users who
+haven't yet made the jump to the Nix Flakes world.
 
 For example, if you have an existing `shell.nix` file, all you need to do is add
 the changes marked as "NEW" from the snippet below:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,12 @@ in
 You can find the full example in
 [`templates/pre-flake-devshell/`](./templates/pre-flake-devshell/).
 
-It should be noted that unlike most traditional Nix projects, this will not build the compilers using your `<nixpkgs>`. Instead it will build them using a fixed Nixpkgs version defined in `flake.lock` of this project. Indeed this is one of the differences how things are usually done with and without flakes, even when it's possible to either pin or to not pin the nixpkgs version regardless of flake use.
+It should be noted that unlike most traditional Nix projects, this will not
+build the compilers using your `<nixpkgs>`. Instead it will build them using a
+fixed Nixpkgs version defined in `flake.lock` of this project. Indeed this is
+one of the differences how things are usually done with and without flakes,
+even when it's possible to either pin or to not pin the nixpkgs version
+regardless of flake use.
 
 ## Source and binary variants
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ in
 You can find the full example in
 [`templates/pre-flake-devshell/`](./templates/pre-flake-devshell/).
 
+It should be noted that unlike most traditional Nix projects, this will not build the compilers using your `<nixpkgs>`. Instead it will build them using a fixed Nixpkgs version defined in `flake.lock` of this project. Indeed this is one of the differences how things are usually done with and without flakes, even when it's possible to either pin or to not pin the nixpkgs version regardless of flake use.
+
 ## Source and binary variants
 
 DMD and LDC packages come in two variants: `binary` and `source`.


### PR DESCRIPTION
Ping @PetarKirov . I'm learning flakes all the time but my mindset is still a bit in the pre-flake world and this is one thing that could have surprised me as an user.

Full story: I have flakes installed and I already use them when I simply want to do a build, but it felt too much to figure out at once how I can override the bootstrap compiler with the new-generation nix commands so I did that with good old `nix-build -E` instead - and ended wondering "oh wait, where is `callPackage`? It's called for me but I'm not passing `<nixpkgs>` to `default.nix`!".