### PR TITLE
ci(gh-actions): Misc improvements

### DIFF
--- a/.github/generate-matrix/action.yml
+++ b/.github/generate-matrix/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@v9
+      uses: DeterminateSystems/nix-installer-action@v10
       with:
         extra-conf: accept-flake-config = true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v10
+        with:
+          extra-conf:
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v14
         with:
@@ -93,6 +96,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v10
+        with:
+          extra-conf:
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v14
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,5 +99,8 @@ jobs:
           name: ${{ vars.CACHIX_CACHE }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      - name: Build dev shell
+        run: nix develop .#ci -c echo 'Devshell built successfully.'
+
       - name: Check style
         run: nix develop .#ci -c pre-commit run --all-files

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -15,10 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v26
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v10
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf:
+            accept-flake-config = true
 
       - name: Run `nix flake update`
         id: update-lockfile

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           title: 'Update Nix Flake lockfile'
-          commit-message: ${{ env.COMMIT_MSG }}
+          body-path: ./commit_msg_body.txt
           branch: 'create-pull-request/update-flake-lockfile'
           delete-branch: true
           branch-suffix: timestamp

--- a/scripts/commit_flake_update.bash
+++ b/scripts/commit_flake_update.bash
@@ -12,7 +12,14 @@ if ! git config --get user.name >/dev/null 2>&1 || \
   git config --local user.name "beep boop"
 fi
 
+current_commit="$(git rev-parse HEAD)"
 nix flake update --commit-lock-file
+commit_after_update="$(git rev-parse HEAD)"
+
+if [[ "$commit_after_update" = "$current_commit" ]]; then
+  echo "All flake inputs are up to date."
+  exit 0
+fi
 
 git commit --amend -F - <<EOF
 chore(flake.lock): Update all Flake inputs ($(date -I))

--- a/scripts/commit_flake_update.bash
+++ b/scripts/commit_flake_update.bash
@@ -21,8 +21,19 @@ if [[ "$commit_after_update" = "$current_commit" ]]; then
   exit 0
 fi
 
+msg_file=./commit_msg_body.txt
+{
+  echo '```'
+  git log -1 '--pretty=format:%b' | sed '1,2d'
+  echo '```'
+} > $msg_file
+
 git commit --amend -F - <<EOF
 chore(flake.lock): Update all Flake inputs ($(date -I))
 
-$(git log -1 '--pretty=format:%b' | sed '1,2d')
+$(cat $msg_file)
 EOF
+
+if [ -z "${CI+x}" ]; then
+  rm -v $msg_file
+fi


### PR DESCRIPTION
- ci(gh-actions/check-style): Build the devshell as a separate step
- ci(gh-actions/update-flake-lock): Use `DeterminateSystems/nix-installer-action`
- fix(scripts/commit_flake_update): Exit early if flake inputs are up to date
- ci(gh-actions): Set the PR description to be the same as the commit msg
