### PR TITLE
ci(ch-actions): Replace FlyCI runners with GitHub runners

### DIFF
--- a/lib/mk-gh-actions-matrix.nix
+++ b/lib/mk-gh-actions-matrix.nix
@@ -1,7 +1,6 @@
 { lib, self, ... }:
 rec {
   # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-  # See https://www.flyci.net/#pricing
   nixSystemToGHPlatform = {
     # GH-hosted runners:
     "x86_64-linux" = "ubuntu-latest";
@@ -9,9 +8,8 @@ rec {
     # "x86_64-darwin" = "macos-14"; # - macos-14 is a 3 aarch64 vCPU / 7GB RAM (but it seems faster than the macos-13 one)
     # "aarch64-darwin" = "macos-14";
 
-    # FlyCI-hosted runners:
-    "x86_64-darwin" = "flyci-macos-large-latest-m1";
-    "aarch64-darwin" = "flyci-macos-large-latest-m1";
+    "x86_64-darwin" = "macos-13";
+    "aarch64-darwin" = "macos-latest";
   };
 
   inherit (import ./build-status.nix { inherit lib; }) getBuildStatus;

--- a/scripts/ci-matrix.sh
+++ b/scripts/ci-matrix.sh
@@ -23,7 +23,7 @@ eval_packages_to_json() {
     | {
       "x86_64-linux": "ubuntu-latest",
       "x86_64-darwin": "macos-13",
-      "aarch64-darwin": "flyci-macos-large-latest-m1"
+      "aarch64-darwin": "macos-latest"
     } as $system_to_gh_platform
     | $nix_eval_results
     | map({


### PR DESCRIPTION
PR #96, take two. Credits to @tsonev7.

---

This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).