### PR TITLE
feat(pkgs/dmd): 2.101.2 supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ development environments for the D programming language.
 | package      | version range                          | platforms                      |
 | ------------ | -------------------------------------- | ------------------------------ |
 | `dmd-binary` | 2.079.1 - 2.090.1, 2.098.0             | ✅ Linux x86_64, ✅ macOS x86_64 |
-| `dmd`        | 2.092.1, 2.096.1, 2.098.1, 2.100.2, 2.102.2 - 2.109.1              | ✅ Linux x86_64, ✅ macOS x86_64 |
+| `dmd`        | 2.092.1, 2.096.1, 2.098.1, 2.100.2 - 2.109.1              | ✅ Linux x86_64, ✅ macOS x86_64 |
 | `ldc-binary` | 1.19.0, 1.25.0, 1.28.0, 1.32.1, 1.34.0 | ✅ Linux x86_64, ✅ macOS x86_64 |
 | `ldc`        | 1.30.0                                 | ✅ Linux x86_64, ❌ macOS x86_64 |
 | `dub`        | 1.30.0                                 | ✅ Linux x86_64, ✅ macOS x86_64 |

--- a/pkgs/dmd/supported-source-versions.json
+++ b/pkgs/dmd/supported-source-versions.json
@@ -23,6 +23,11 @@
     "phobos": "sha256-kTHRaAKG7cAGb4IE/NGHWaZ8t7ZceKj03l6E8wLzJzs=",
     "tools": "sha256-2yzdkarbsf0kOXzLaS6bvBFoiYbDulnEHTozmHX3Oc4="
   },
+  "2.101.2": {
+    "dmd": "sha256-qxhDb8CD3ou+eQLiVnR9K1/FYEv2HhSNtapV9VXtS5w=",
+    "phobos": "sha256-XKpTm/GdaRY8TTjWQ2h2jbUlSZZ7VRP6MyLJyDUjKiE=",
+    "tools": "sha256-faiKE7a6qyl3MoDvkXcRmGGjFRYYK0gWRihJjG2I46k="
+  },
   "2.102.2": {
     "dmd": "sha256-der9nb31hJ+K1aJZdzIgs8+eRgVVsH97QnYEnVbKUws=",
     "phobos": "sha256-SracmUm2aY/LDCyDqYuVS39pCbwO8UCL3TSB0CVHpHE=",


### PR DESCRIPTION
2.101 is the first version with unified DMD/DRuntime repo, and also has a lot of changes from 2.100. I felt it's special enough to add support for.