### PR TITLE
feat(flake.lock): updated flake inputs.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
         "type": "github"
       },
       "original": {
@@ -43,17 +43,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1747372754,
+        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
         "type": "github"
       },
       "original": {
@@ -85,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732521221,
-        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -206,6 +206,31 @@ stdenv.mkDerivation rec {
         sha256 = "sha256-JO52sxliPFjCe4qyo/eyWhDTg1x5bh1+7gPj1SYXIh8=";
       })
     ]
+    ++ lib.optionals (versionBetween "2.099.0" "2.111.0" version) [
+      # GCC started giving warnings on preprocessor undefinitons
+      # that were implicitly added to every C file by DMD.
+      (fetchpatch {
+        url = "https://github.com/dlang/dmd/commit/9773c41a1323642cce6ce47810a6c8b5ec31e5c6.patch";
+        stripLen = 2;
+        extraPrefix = druntimePrefix + "/";
+        sha256 =
+          if druntimeRepo then
+            "sha256-wfFSqg38YbNZI7kUbvwyMs7RjydS4e0CpIKsjvZGTWU="
+          else
+            "sha256-nvq2JWbdNOuEfNOqZOw5ymB8OYEdR87EbqbQU7J60QE=";
+      })
+    ]
+    ++ lib.optionals (versionBetween "2.101.0" "2.112.0" version) [
+      # MacOS 15.4 siletly changed thread-local storage ABI breaking all DRuntimes
+      # built with compilers starting from 2.099.0
+      # https://github.com/dlang/dmd/issues/21126
+      (fetchpatch {
+        url = "https://github.com/dlang/dmd/commit/5febad2e92dbabcd797abae13b6f9a392e3783f6.patch";
+        stripLen = 1;
+        extraPrefix = "dmd/";
+        sha256 = "sha256-In6YndwS4tDASo0AQ6aUBYDf8SSx7E2TqwuE8tpwjfM=";
+      })
+    ]
     ++ lib.optionals (versionBetween "2.102.2" "2.104.0" version) [
       (fetchpatch {
         # Fix for: https://issues.dlang.org/show_bug.cgi?id=23846

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -206,6 +206,22 @@ stdenv.mkDerivation rec {
         sha256 = "sha256-JO52sxliPFjCe4qyo/eyWhDTg1x5bh1+7gPj1SYXIh8=";
       })
     ]
+    ++ lib.optionals (versionBetween "2.102.2" "2.104.0" version) [
+      (fetchpatch {
+        # Fix for: https://issues.dlang.org/show_bug.cgi?id=23846
+        # Implemented in: https://github.com/dlang/dmd/pull/15139
+        url = "https://github.com/dlang/dmd/commit/deaf1b81986c57d31a1b1163301ca4d157505220.patch";
+        stripLen = 1;
+        extraPrefix = "dmd/";
+        sha256 = "sha256-xgaIraFH3ZfIn99ms148MP7cKV63JgU90yEYq21noRw=";
+      })
+    ]
+    ++ lib.optionals (lib.versionOlder version "2.108.0") [
+      # Fixes a latent ZLib C header bug. In DMD, it if fixed for 2.108.0
+      # by upgrading ZLib to 1.3.1 but we don't do that here because it would
+      # be less faithful to the langauge as it existed before that.
+      ./patches/zlib-darwin-header.patch
+    ]
     ++ lib.optionals (versionBetween "2.099.0" "2.111.0" version) [
       # GCC started giving warnings on preprocessor undefinitons
       # that were implicitly added to every C file by DMD.
@@ -220,6 +236,16 @@ stdenv.mkDerivation rec {
             "sha256-nvq2JWbdNOuEfNOqZOw5ymB8OYEdR87EbqbQU7J60QE=";
       })
     ]
+    ++ lib.optionals (lib.versionOlder version "2.111.0" && !druntimeRepo) [
+      (fetchpatch {
+        # Linker started demangling a D symbol in an error message,
+        # breaking this test before a patch.
+        url = "https://github.com/dlang/dmd/commit/dfe0f34b2aa59e6cf4526c9af8069e08638149bc.patch";
+        stripLen = 1;
+        extraPrefix = "dmd/";
+        hash = "sha256-Uccb8rBPBLAEPWbOYWgdR5xN3wJoIkKKhLGu58IK1sM=";
+      })
+    ]
     ++ lib.optionals (versionBetween "2.101.0" "2.112.0" version) [
       # MacOS 15.4 siletly changed thread-local storage ABI breaking all DRuntimes
       # built with compilers starting from 2.099.0
@@ -229,26 +255,6 @@ stdenv.mkDerivation rec {
         stripLen = 1;
         extraPrefix = "dmd/";
         sha256 = "sha256-In6YndwS4tDASo0AQ6aUBYDf8SSx7E2TqwuE8tpwjfM=";
-      })
-    ]
-    ++ lib.optionals (versionBetween "2.102.2" "2.104.0" version) [
-      (fetchpatch {
-        # Fix for: https://issues.dlang.org/show_bug.cgi?id=23846
-        # Implemented in: https://github.com/dlang/dmd/pull/15139
-        url = "https://github.com/dlang/dmd/commit/deaf1b81986c57d31a1b1163301ca4d157505220.patch";
-        stripLen = 1;
-        extraPrefix = "dmd/";
-        sha256 = "sha256-xgaIraFH3ZfIn99ms148MP7cKV63JgU90yEYq21noRw=";
-      })
-    ]
-    ++ lib.optionals (lib.versionOlder version "2.111.0" && !druntimeRepo) [
-      (fetchpatch {
-        # Linker started demangling a D symbol in an error message,
-        # breaking this test before a patch.
-        url = "https://github.com/dlang/dmd/commit/dfe0f34b2aa59e6cf4526c9af8069e08638149bc.patch";
-        stripLen = 1;
-        extraPrefix = "dmd/";
-        hash = "sha256-Uccb8rBPBLAEPWbOYWgdR5xN3wJoIkKKhLGu58IK1sM=";
       })
     ];
 

--- a/pkgs/dmd/patches/zlib-darwin-header.patch
+++ b/pkgs/dmd/patches/zlib-darwin-header.patch
@@ -1,0 +1,32 @@
+Patch written specifically for dlang.nix by Ate Eskola
+
+This conditional and it's "else" branch seems to be some copypasta bug that
+I suspect previously compiled because stdio, which is included after
+this definition, previously defined fdopen by macro that overwrote
+this, but stopped compiling when stdio made it a function definition
+instead. Didn't check if that's the case though.
+
+In any case the conditions are senseless: it is already established this is a
+MacOS, and __MWERKS__ seems to be a long-obsolete compiler ID
+(source: https://stackoverflow.com/questions/19584527/where-is-mwerks-in-os10-7).
+There is nothing compiler-specific here.
+
+diff --git a/etc/c/zlib/zutil.h b/etc/c/zlib/zutil.h
+index d9a20ae1b..67984964e 100644
+--- a/phobos/etc/c/zlib/zutil.h
++++ b/phobos/etc/c/zlib/zutil.h
+@@ -140,13 +140,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #if defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-#      include <unix.h> /* for fdopen */
++#    include <stdio.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
+-#    endif
+ #  endif
+ #endif
+ 


### PR DESCRIPTION
So flake updates by the bot have been failing for a good time. I did this flake update (admittedly still a few months behind) and fixed errors that popped up for two or three different DMD versions. I'll let the CI to find any possible remaining errors.

Ping @PetarKirov .