### PR TITLE
fix(pkgs/dmd): harden darwin MACOSX_DEPLOYMENT_TARGET handling

### DIFF
--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -32,6 +32,7 @@
   installShellFiles,
   git,
   unzip,
+  darwinMinVersionHook,
   hostDCompiler,
 }:
 let
@@ -40,6 +41,11 @@ let
   inherit (import ../../lib/dc.nix { inherit lib; }) getDCInfo;
 
   hostDCInfo = getDCInfo hostDCompiler;
+
+  # Minimum macOS version every Darwin compiler/linker invocation should target.
+  # Only forced under `stdenv.isDarwin` guards, so it stays lazy on Linux where
+  # the attribute is absent.
+  darwinTarget = stdenv.hostPlatform.darwinMinVersion;
 
   buildStatus = getBuildStatus "dmd" version stdenv.system;
 
@@ -316,15 +322,21 @@ stdenv.mkDerivation rec {
     + lib.optionalString (versionBetween "2.092.0" "2.110.0" version) ''
       substituteInPlace ${dmdPrefix}/src/build.d --replace '"-w", "-de",' ""
     ''
-    # DMD's build/druntime makefiles hardcode `MACOSX_DEPLOYMENT_TARGET=10.9`.
-    # Binaries built for 10.9 segfault at runtime on recent macOS (the old
-    # TLS/dyld ABI), which fails the test suite on the macos-26 runner. Bump
-    # every occurrence to the toolchain's min version so the runtime libs and
-    # the compiled test binaries target a macOS the runner can execute.
+    # druntime and phobos hardcode `export MACOSX_DEPLOYMENT_TARGET=10.9` in
+    # their makefiles. That is a GNU make assignment, which overrides the
+    # inherited environment, so patching the file is the only way to change it
+    # for those library builds. Binaries stamped for 10.9 segfault at runtime on
+    # recent macOS (the old TLS/dyld ABI), failing the test suite on the
+    # macos-26 runner; rewrite the value to the toolchain's min version. The
+    # makefile is `posix.mak` in older releases and `Makefile` from 2.112 on, so
+    # cover both: the guard skips files a given version doesn't ship and
+    # `--replace-quiet` tolerates the line being absent.
     + lib.optionalString stdenv.isDarwin ''
-      grep -rlF 'MACOSX_DEPLOYMENT_TARGET=10.9' . | while read -r mk; do
-        substituteInPlace "$mk" \
-          --replace 'MACOSX_DEPLOYMENT_TARGET=10.9' 'MACOSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}'
+      for mk in ${druntimePrefix}/posix.mak ${druntimePrefix}/Makefile phobos/posix.mak phobos/Makefile; do
+        if [ -e "$mk" ]; then
+          substituteInPlace "$mk" \
+            --replace-quiet 'MACOSX_DEPLOYMENT_TARGET=10.9' 'MACOSX_DEPLOYMENT_TARGET=${darwinTarget}'
+        fi
       done
     ''
     + ''
@@ -360,10 +372,19 @@ stdenv.mkDerivation rec {
     installShellFiles
   ] ++ lib.optional (lib.versionOlder version "2.088.0") git;
 
-  buildInputs = [
-    curl
-    tzdata
-  ] ++ lib.optional stdenv.isDarwin Foundation;
+  buildInputs =
+    [
+      curl
+      tzdata
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      Foundation
+      # Exports MACOSX_DEPLOYMENT_TARGET for every build/check phase. Covers the
+      # compiler invocations the druntime/phobos makefiles don't drive (building
+      # dmd itself, the test harness) — without it DMD's codegen falls back to its
+      # hardcoded 10.9 default (compiler/src/dmd/backend/machobj.d).
+      (darwinMinVersionHook darwinTarget)
+    ];
 
   nativeCheckInputs = [ gdb ] ++ lib.optional (lib.versionOlder version "2.089.0") unzip;
 
@@ -403,7 +424,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
     ${lib.optionalString (buildStatus.skippedTests != [ ]) (
-      lib.concatMapStringsSep "\n" (test: ''rm -v ${test}'') buildStatus.skippedTests
+      lib.concatMapStringsSep "\n" (test: "rm -v ${test}") buildStatus.skippedTests
     )}
     export checkJobs=$NIX_BUILD_CORES
     if [ -z $enableParallelChecking ]; then
@@ -443,7 +464,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/dmd \
       --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
-      --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
+      --set-default CC "${targetPackages.stdenv.cc}/bin/cc"${lib.optionalString stdenv.isDarwin " \\\n      --set-default MACOSX_DEPLOYMENT_TARGET \"${darwinTarget}\""}
 
     substitute ${dmdConfFile} "$out/bin/dmd.conf" --subst-var out
 


### PR DESCRIPTION
Follow-up to #197 - I wasn't satisfied with the way `MACOSX_DEPLOYMENT_TARGET` was handled in 5e54bcd3fcda3ee8b5fd880ca6f8bbea3f9e1025.

---

The initial fix rewrote the hardcoded `MACOSX_DEPLOYMENT_TARGET=10.9` with a tree-wide `grep`, which only covered the druntime/phobos library builds and could touch non-makefiles. It missed every context that reads the value from the **environment**, where DMD's codegen otherwise falls back to its hardcoded 10.9 default ([`compiler/src/dmd/backend/machobj.d`](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/machobj.d)).

This replaces it with a more robust and complete approach, all derived from `stdenv.hostPlatform.darwinMinVersion`:

- **`substituteInPlace` only the druntime/phobos makefiles** (`posix.mak` before 2.112, `Makefile` from 2.112 on) with an existence guard and `--replace-quiet`, instead of grepping the whole source tree. A make `export` assignment overrides the inherited environment, so those libraries can only be retargeted by patching the file.
- **`darwinMinVersionHook` in `buildInputs`** so `MACOSX_DEPLOYMENT_TARGET` is exported for the invocations the makefiles don't drive (building dmd itself, the `run.d` test harness), instead of falling back to 10.9.
- **`wrapProgram --set-default`** on the installed dmd so user-compiled binaries get a sane floor when the variable is absent from the shell.

### No Linux impact
The darwin-only `--set-default` is folded into the preceding wrapper line so the Linux `installPhase` is byte-identical to before — **0/128 `x86_64-linux` drvPaths change** vs the merge base (no spurious rebuilds).

### Verification
Built on macOS 26 (x86_64 via Rosetta): `dmd-2.110.0` builds (exit 0) and the shipped `libphobos2` is stamped `LC_VERSION_MIN_MACOSX version 11.3` (previously 10.9).

> [!NOTE]
> Separately observed (pre-existing, **not** introduced here): the installed compiler can't link a trivial program against the static-only `libphobos2.a` on macOS 26 — `rt_envvars_enabled`/`rt_options` are emitted as common symbols the current linker won't pull from the archive. Confirmed independent of the deployment target (fails identically at 10.9 and with `-no_fixup_chains`). Consistent with the darwin test suite already being disabled. Can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)