### PR TITLE
feat: dub fetcher support and full dub package backfill (1.0.0–1.43.0)

### DIFF
--- a/lib/version-catalog.nix
+++ b/lib/version-catalog.nix
@@ -18,10 +18,16 @@ let
   callWithExtras =
     package:
     let
-      result' = callPackage package {
+      # Only pass each extra argument to functions that declare it: dub's
+      # `dCompiler` must not be forced on dmd/ldc and vice versa. The version
+      # catalogs override these defaults per version by gluing the chosen
+      # compiler onto their result (see e.g. pkgs/dub/version-catalog.nix).
+      extraArgs = {
         hostDCompiler = result'.hostDCompiler or self'.packages.ldc-bootstrap;
+        dCompiler = result'.dCompiler or self'.packages.ldc;
         inherit (pkgs.darwin.apple_sdk.frameworks) Foundation;
       };
+      result' = callPackage package (lib.intersectAttrs (lib.functionArgs package) extraArgs);
     in
     result';
 

--- a/pkgs/dub/build-status.nix
+++ b/pkgs/dub/build-status.nix
@@ -111,9 +111,24 @@ let
   ];
 
   getSkippedTests =
-    version:
+    version: system:
     baseSkippedTests
-    ++ lib.optionals (versionAtLeast version "1.41.0") [
+    # removed-dub-obj.sh expects `.dub/build/library-*ldc*/obj/test.o*`, but
+    # newer LDCs no longer produce that obj layout; dc-env.sh fails with the
+    # modern host compiler as well. Both were reworked in 1.25.0.
+    ++ lib.optionals (lib.versionOlder version "1.25.0") [
+      "removed-dub-obj.sh"
+      "dc-env.sh"
+    ]
+    # Uses BSD `stat -f '%m'`, but the nix sandbox provides GNU stat on
+    # darwin as well; the test was reworked in 1.25.0.
+    ++ lib.optionals (lib.versionOlder version "1.25.0" && lib.hasSuffix "darwin" system) [
+      "cache-generated-test-config.sh"
+    ]
+    # These tests fail in the nix sandbox from the version they were each
+    # introduced in (1.33/1.34/1.35/1.40); `rm -rf` of the not-yet-existing
+    # directories is a no-op on older versions.
+    ++ lib.optionals (versionAtLeast version "1.33.0") [
       "issue2698-cimportpaths-broken-with-dmd-ldc"
       "pr2642-cache-db"
       "pr2644-describe-artifact-path"
@@ -137,9 +152,36 @@ let
         nameValuePair system {
           build = true;
           check = true;
-          skippedTests = getSkippedTests version;
+          skippedTests = getSkippedTests version system;
         }
       ) systems
     );
 in
-mergeVersions [ (between "1.30.0" latestVersion (version: makeSystemAttrs version)) ]
+mergeVersions [
+  # dub <= 1.19.0 cannot be built with the current packaging:
+  # - 1.0.0 - 1.6.0: postPatch fails (test/fetchzip.sh does not exist yet)
+  # - 1.7.2 - 1.19.0: pre-build.d build system (no ./build.d)
+  (between "1.0.0" "1.19.0" (
+    _version:
+    listToAttrs (
+      map (
+        system:
+        nameValuePair system {
+          build = false;
+          check = false;
+          skippedTests = [ ];
+        }
+      ) systems
+    )
+  ))
+  # 1.20.1 - 1.23.0 use std.xml (removed from newer Phobos), so they pin an
+  # older host compiler via `d-compiler` in supported-source-versions.json.
+  (between "1.20.1" latestVersion (version: makeSystemAttrs version))
+  {
+    "1.23.0" = {
+      x86_64-darwin = {
+        check = false;
+      };
+    };
+  }
+]

--- a/pkgs/dub/default.nix
+++ b/pkgs/dub/default.nix
@@ -10,18 +10,16 @@
   curl,
   libevent,
   rsync,
-  ldc,
-  dcompiler ? ldc,
+  dCompiler,
   ...
 }:
-assert dcompiler != null;
 let
   inherit (import ../../lib/build-status.nix { inherit lib; }) getBuildStatus;
   inherit (import ../../lib/dc.nix { inherit lib; }) getDCInfo;
 
   buildStatus = getBuildStatus "dub" version stdenv.system;
 
-  hostDCInfo = getDCInfo dcompiler;
+  hostDCInfo = getDCInfo dCompiler;
 in
 stdenv.mkDerivation rec {
   pname = "dub";
@@ -51,7 +49,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    dcompiler
+    dCompiler
     libevent
     rsync
   ];

--- a/pkgs/dub/supported-source-versions.json
+++ b/pkgs/dub/supported-source-versions.json
@@ -80,18 +80,22 @@
     "rev": "08ebe85e154dfedcc8ac21fb96bef30beb956209"
   },
   "1.20.1": {
+    "d-compiler": "ldc-binary-1_28_0",
     "dub": "sha256-TpOo5/AVlw0aVeEUJG4Z78ZFbhCwhZWts6oukykRjNM=",
     "rev": "03ea8a03fe3e4e784107d58fce254bec2140bd1b"
   },
   "1.21.0": {
+    "d-compiler": "ldc-binary-1_28_0",
     "dub": "sha256-7pAThfKqamN/sQewPvuaKdi/plzxyuT5FQ2xJSKNEeU=",
     "rev": "fd568a250ae8a5917e551ce1ca87dc4e2d12ffc4"
   },
   "1.22.0": {
+    "d-compiler": "ldc-binary-1_28_0",
     "dub": "sha256-vcADnX3kx0mowKq9w27ytGyIisvbGXAGCob5+cGszrQ=",
     "rev": "8e3d4c13dc95ce5a4cdf9f41fd537e1ea1c77cd9"
   },
   "1.23.0": {
+    "d-compiler": "ldc-binary-1_28_0",
     "dub": "sha256-vqn6QlPMFc/sVbwHeU/eQ/1jB3KRW5PABMDUQDXkRBk=",
     "rev": "4395f8f8fc9a8b3d47fec5e09b002ac75e3b2083"
   },
@@ -120,6 +124,7 @@
     "rev": "f1bddccb1d999b312f4887c85068f9742c2c444e"
   },
   "1.30.0": {
+    "d-compiler": "ldc-binary-1_28_0",
     "dub": "sha256-iVl7bjblvIxvrUX7Phq6h4AIAmZjNVkGYYFA1hhsE7c=",
     "rev": "37656524a8448315331883630f99f305664a9240"
   },

--- a/pkgs/dub/supported-source-versions.json
+++ b/pkgs/dub/supported-source-versions.json
@@ -3,7 +3,8 @@
     "dub": "sha256-iVl7bjblvIxvrUX7Phq6h4AIAmZjNVkGYYFA1hhsE7c="
   },
   "1.41.0": {
-    "dub": "sha256-86TzaRdu+CFM0Ld2fXxjaUUT9dl37MYPdmsvxE4ZUkE="
+    "dub": "sha256-86TzaRdu+CFM0Ld2fXxjaUUT9dl37MYPdmsvxE4ZUkE=",
+    "rev": "59c08ed1c788db1c02807c6b3cdad846c342efd2"
   },
   "1.42.0-beta.1": {
     "dub": "sha256-vxaDC47QdjSpWon5FltcIJsmDwUsUmJc5A1Lbdw6W7w="

--- a/pkgs/dub/supported-source-versions.json
+++ b/pkgs/dub/supported-source-versions.json
@@ -1,6 +1,167 @@
 {
+  "1.0.0": {
+    "dub": "sha256-EMpbuZDLQxn/Z9zxO0bKGRNSQ1JEku4kiYPJBCsURR8=",
+    "rev": "b59af2b8befb4fad4157d8c9cc86dba707b2fc87"
+  },
+  "1.1.2": {
+    "dub": "sha256-M8/lP7rBYzpF+q8UUHIqp1+3ZAwyQSSjBwwZBqD2v2k=",
+    "rev": "6353f43d00dafa775d4bbbbcdebc1682f87bbc6f"
+  },
+  "1.2.2": {
+    "dub": "sha256-zdLAnC4rw3hHC2wcBSgjJd+dkjto6DUEZjXkdlEI8LE=",
+    "rev": "4fbb1280f0e5d5848bce23a4a0ee6e5d7ffff337"
+  },
+  "1.3.0": {
+    "dub": "sha256-HGbao/MLsyGB6/Txc15kk+moi3oqFE7GWcdoDcFGgnw=",
+    "rev": "907c3cae18054ac088cdc2d0a094d0e6a49b06d8"
+  },
+  "1.4.1": {
+    "dub": "sha256-1wkO6dXXxFqG6Zw5TP0EH6EouhRKq1hF15D0o7NW/Uw=",
+    "rev": "029ed323555c1f1770314a2b9a8d28cc8f165030"
+  },
+  "1.5.0": {
+    "dub": "sha256-BW8j58NODenBFd7u27xqH433LMTcVty4zPFDGUnPsU4=",
+    "rev": "9464a576b2734ec56a476b507db3ecb1c66081a8"
+  },
+  "1.6.0": {
+    "dub": "sha256-85/68o/OGHtNlMN4H5P8E+ADlw++ZwVJY4sOI+4tWfY=",
+    "rev": "5f4fe50599da1f5853e6313fd99a0f11f121b766"
+  },
+  "1.7.2": {
+    "dub": "sha256-iZulAWv7cRZ37ZaksAa055jrc9oqSx80ZvC+UN9ecRw=",
+    "rev": "208d4f059b7effcedef4ccd4393494e4010e7d16"
+  },
+  "1.8.1": {
+    "dub": "sha256-pinnY8lSIzOII/lCOde+0plcPZK8Gr21lq5spyXpJ5s=",
+    "rev": "02cc679762d0cfd3e9f833c8b0a1d71b1f06b37b"
+  },
+  "1.9.0": {
+    "dub": "sha256-PrOtBE2zpX1XMEeAYly0zGmChR1C+Me40GC9SI9pCYk=",
+    "rev": "ddf6601ecfb5f2fa9d2b0d4d23281941dca26c5f"
+  },
+  "1.10.0": {
+    "dub": "sha256-xI7QvXP4bz3UfSnWX4z2wsA16C5wg88XlkcQLZm7vQs=",
+    "rev": "6b0cdc0288e14c81725af0421f589e9c88df6cea"
+  },
+  "1.11.0": {
+    "dub": "sha256-998kBnG64FNR5AMS4xPemFVbfWaT+1SxhcUqbt9M5tI=",
+    "rev": "9065964db9d8e1cf35aff53cb8c16417a754e005"
+  },
+  "1.12.1": {
+    "dub": "sha256-ShT1vDy5GGoNw+7WiptSx/HWsDZyN8i9wbC71zcyiWA=",
+    "rev": "6963c4645e727f19b79d8e9620befa24e16851f2"
+  },
+  "1.13.0": {
+    "dub": "sha256-G8ufBIu+JS2eCOtZJT0j+iLxI+AIhbfWGNIptWy7pfE=",
+    "rev": "41d1c11bc34d247b1c73b124c90b19bb6a47c0ad"
+  },
+  "1.14.0": {
+    "dub": "sha256-BLlb2TTrSvXazKuqwEuipwMmCCrIMbhg8Cjlmf10Exw=",
+    "rev": "05ec4f664d8a626a63d74a0b129a6bb7b38f89d4"
+  },
+  "1.15.0": {
+    "dub": "sha256-u9AvPL/zapMZ3mV4kXjo+tFzUSFNQ5f0oIErndLwKq0=",
+    "rev": "5307c86b4916c3dd32c2143475e2b49b56578a1a"
+  },
+  "1.16.0": {
+    "dub": "sha256-fECfb4AgkGcVo/SlcNEfwIQadnIBcJiS7l4fmgnssHE=",
+    "rev": "6c8fbaea6ee9d179898166a03727b88e3f91cdf0"
+  },
+  "1.17.0": {
+    "dub": "sha256-7ZXWMvVIypZRE+TQcwBWMMR2G6FAC31zSy3IPZks2mM=",
+    "rev": "5815b06d0ef2b30b0746d5ceb3070ac81ae8169c"
+  },
+  "1.18.0": {
+    "dub": "sha256-KE9ku24VG0IaPFI38Y10TvRGzmYI/A2SIgNltAP9uO0=",
+    "rev": "2c5e115646cfda4a4496ae8ecd189ed992fece94"
+  },
+  "1.19.0": {
+    "dub": "sha256-se2tm7K2V18kXw4qQItq8CBbBF+uL6VFTk0NGE/8ARo=",
+    "rev": "08ebe85e154dfedcc8ac21fb96bef30beb956209"
+  },
+  "1.20.1": {
+    "dub": "sha256-TpOo5/AVlw0aVeEUJG4Z78ZFbhCwhZWts6oukykRjNM=",
+    "rev": "03ea8a03fe3e4e784107d58fce254bec2140bd1b"
+  },
+  "1.21.0": {
+    "dub": "sha256-7pAThfKqamN/sQewPvuaKdi/plzxyuT5FQ2xJSKNEeU=",
+    "rev": "fd568a250ae8a5917e551ce1ca87dc4e2d12ffc4"
+  },
+  "1.22.0": {
+    "dub": "sha256-vcADnX3kx0mowKq9w27ytGyIisvbGXAGCob5+cGszrQ=",
+    "rev": "8e3d4c13dc95ce5a4cdf9f41fd537e1ea1c77cd9"
+  },
+  "1.23.0": {
+    "dub": "sha256-vqn6QlPMFc/sVbwHeU/eQ/1jB3KRW5PABMDUQDXkRBk=",
+    "rev": "4395f8f8fc9a8b3d47fec5e09b002ac75e3b2083"
+  },
+  "1.24.1": {
+    "dub": "sha256-JVbRAvB6sigyHJzqKuJ5zb1uBcmztjFd+sJvnEdpqMs=",
+    "rev": "8ac466a97cbcceb9d051648cbbbe0ba51e379677"
+  },
+  "1.25.0": {
+    "dub": "sha256-EnJDMXiJGf2FO0QMAjX3kwYZNYPVcHbepHypGk2Ol+Y=",
+    "rev": "07d30eed45a61b1da489555add31b6959ac8530f"
+  },
+  "1.26.1": {
+    "dub": "sha256-CNIB9swfrWwTB7IXoJmtMyJiCYD/z73uU6NrTLChx94=",
+    "rev": "3d68d554c4f45bbb0f822e691fdb37b0b91d3a8c"
+  },
+  "1.27.0": {
+    "dub": "sha256-qLlqPhwiCATlgS1ANtAH1A4KTcG1cTs/UlVfLkl0Ov8=",
+    "rev": "7145f2c3d8f06a64b2012113a9aa3548e1cdbe58"
+  },
+  "1.28.0": {
+    "dub": "sha256-GOeaQyu8Y/DxZEAJPdlGH9ie/ZRTqvAw2jjvM3dESbg=",
+    "rev": "305b8c2ec986032357821a307a55c7afc7d4aa6b"
+  },
+  "1.29.2": {
+    "dub": "sha256-bxH1DgTejo3M/O9b7tWHyz6vWDO3KsY9K1hbysdWBks=",
+    "rev": "f1bddccb1d999b312f4887c85068f9742c2c444e"
+  },
   "1.30.0": {
-    "dub": "sha256-iVl7bjblvIxvrUX7Phq6h4AIAmZjNVkGYYFA1hhsE7c="
+    "dub": "sha256-iVl7bjblvIxvrUX7Phq6h4AIAmZjNVkGYYFA1hhsE7c=",
+    "rev": "37656524a8448315331883630f99f305664a9240"
+  },
+  "1.31.1": {
+    "dub": "sha256-dp64D51ypowXS1+EYKRXh5hpa3rMmiotvKO2FW+i92w=",
+    "rev": "cedf3155fa9201db8996bcff12064b813df6ac69"
+  },
+  "1.32.1": {
+    "dub": "sha256-5pW3Fu3PQ1ZLJnsuh7fPpEBNbVQgGfFyiuMrAVOJKQA=",
+    "rev": "f5cd2ce5fd718baab0339a9af9c7003474461805"
+  },
+  "1.33.1": {
+    "dub": "sha256-QFgUsO04VRXBDjGI5QQs7u9XrexG7/V34TMgJP1D8yA=",
+    "rev": "0e8b10ad2b177e133ea4e439a105a39229fc30eb"
+  },
+  "1.34.0": {
+    "dub": "sha256-hC46XKE6lLLMLGMGl4vDnLDBQy6P/Z7o3ayDJj0Sois=",
+    "rev": "a1172d256446814948221e9b275ca95afa4588af"
+  },
+  "1.35.1": {
+    "dub": "sha256-bdd0ABoGoA6V6xuQNbNI8+NM17M52N9+TeN6va+2nbQ=",
+    "rev": "53daf6a9231381cf5ba9c19d8c7e7fe9bff2e8af"
+  },
+  "1.36.0": {
+    "dub": "sha256-S8pls9zxbGAQTwqYf4bDT2q7Ow12S8bBsJE5UmsACBs=",
+    "rev": "0d4858eb473a31a058132c8692d499effdb1cb28"
+  },
+  "1.37.0": {
+    "dub": "sha256-5P/KSZoew8V4h3LA/4VEzC6xN9U42v1vEiG+K5xzmDc=",
+    "rev": "203dc55ce3db4d84a719324c5c330da23b457317"
+  },
+  "1.38.1": {
+    "dub": "sha256-8Lr/0sx4SKwU1aNOxZArta0RXpDM+EWl29ZsPDdPWFo=",
+    "rev": "fbf3c173746cd33f09486d8552beaddb8b24d658"
+  },
+  "1.39.0": {
+    "dub": "sha256-73b15A9+hClD6IbuxTy9QZKpTKjUFYBuqGOclUyhrnM=",
+    "rev": "b0cc8ea274455d494a3b6a54d05a019800df338d"
+  },
+  "1.40.0": {
+    "dub": "sha256-OirchEKf66gis70gCSTOYcrHLyHhCsyt/rTEGT83Vcc=",
+    "rev": "ac94c79cbe16c5e2cfec1ad9129c15d75f0dc6fc"
   },
   "1.41.0": {
     "dub": "sha256-86TzaRdu+CFM0Ld2fXxjaUUT9dl37MYPdmsvxE4ZUkE=",

--- a/pkgs/dub/version-catalog.nix
+++ b/pkgs/dub/version-catalog.nix
@@ -6,16 +6,24 @@ lib: rec {
   getBinaryVersion = null; # unsupported
 
   getSourceVersion =
-    pkgs: version:
+    ourPkgs: version:
     assert builtins.hasAttr version supportedVersions.source;
     let
       componentHashes = supportedVersions.source."${version}";
+      package = import ./default.nix (
+        {
+          inherit version;
+          dubSha256 = componentHashes.dub;
+        }
+        // lib.optionalAttrs (componentHashes ? rev) { inherit (componentHashes) rev; }
+      );
     in
-    import ./default.nix (
-      {
-        inherit version;
-        dubSha256 = componentHashes.dub;
+    lib.mirrorFunctionArgs package (
+      nixpkgs:
+      package nixpkgs
+      // {
+        ${if componentHashes ? d-compiler then "dCompiler" else null} =
+          ourPkgs.${componentHashes.d-compiler};
       }
-      // lib.optionalAttrs (componentHashes ? rev) { inherit (componentHashes) rev; }
     );
 }

--- a/src/dlang_nix/components.d
+++ b/src/dlang_nix/components.d
@@ -8,7 +8,7 @@ import std.path : buildNormalizedPath, dirName;
 
 import sparkles.versions : SemVer, Dmd;
 
-import dlang_nix.utils.commands : Hash, Url, resolveVersionRange;
+import dlang_nix.utils.commands : Hash, Url, resolveTagRevs, resolveVersionRange;
 
 alias Version = string;
 alias Platform = string;
@@ -21,9 +21,15 @@ alias Platform = string;
 alias VersionRangeResolver =
     Version[] function(string tagsRepo, string first, string last);
 
+/// Resolves each requested version to the commit hash its release tag
+/// points to (for fetchers that pin an explicit `rev`). Impure
+/// (`@system`) since it shells out to `git ls-remote`.
+alias RevResolver =
+    Hash[Version] function(string tagsRepo, const Version[] versions);
+
 @safe pure:
 
-enum Component { dmd, dmd_src, ldc, ldc_src };
+enum Component { dmd, dmd_src, ldc, ldc_src, dub };
 
 alias UrlFormatter = Url function(Platform platform, Version compilerVersion);
 
@@ -39,6 +45,7 @@ struct ComponentInfo {
     string tagsRepo;   // "owner/repo" on GitHub for tag discovery
     Version[] defaultVersions;  // fetched when no versions are requested
     VersionRangeResolver resolveVersions;
+    RevResolver resolveRevs;  // set when the nix fetcher pins an explicit rev
 }
 
 string suffix(Platform p) => p.startsWith("windows") ? "7z" : "tar.xz";
@@ -103,5 +110,19 @@ enum ComponentInfo[Component] supportedPlatforms = [
         tagsRepo: "ldc-developers/ldc",
         defaultVersions: [ "1.35.0" ],
         resolveVersions: &resolveVersionRange!SemVer,
+    ),
+    Component.dub: ComponentInfo(
+        urlFormatter: (platform, compilerVersion) =>
+            "https://github.com/dlang/%s/archive/refs/tags/v%s.tar.gz"
+                .format(platform, compilerVersion),
+        platforms: compVersion => [
+            "dub"
+        ],
+        unpackingNeed: UnpackingNeeded.yes,
+        supportedVersionsFile: pkgsDir.buildNormalizedPath("dub", "supported-source-versions.json"),
+        tagsRepo: "dlang/dub",
+        defaultVersions: [ "1.41.0" ],
+        resolveVersions: &resolveVersionRange!SemVer,
+        resolveRevs: &resolveTagRevs,
     ),
 ];

--- a/src/dlang_nix/utils/commands.d
+++ b/src/dlang_nix/utils/commands.d
@@ -1,15 +1,16 @@
 module dlang_nix.utils.commands;
 
-import std.algorithm : filter, joiner, map, maxElement, sort, startsWith, endsWith, uniq;
+import std.algorithm : countUntil, filter, find, joiner, map, maxElement, sort, startsWith, endsWith, uniq;
 import std.array : array;
 import std.conv : to;
 import std.exception : enforce;
 import std.file : exists;
 import std.format : format;
 import std.process : executeShell, Config;
+import std.range : empty, front;
 import std.stdio : stderr;
 import std.string : indexOf, outdent, splitLines, strip;
-import std.typecons : tuple;
+import std.typecons : Tuple, tuple;
 
 import sparkles.versions.traits : hasSemVerComponents, supportsPrerelease;
 
@@ -143,18 +144,37 @@ unittest {
 // ---------------------------------------------------------------------------
 // Tag fetcher.
 //
-// Uses `git ls-remote --tags --refs <url>` — no auth required, works for
-// any GitHub repo. `--refs` filters out peeled refs (`^{}`); we strip them
-// defensively too.
+// Uses `git ls-remote --tags <url>` — no auth required, works for any
+// GitHub repo. Peeled refs (`^{}`) are kept during parsing: for annotated
+// tags they carry the commit hash the tag points to (the direct ref only
+// has the tag object's hash).
 // ---------------------------------------------------------------------------
 
-/// Fetches tag names from a GitHub `"owner/repo"` via `git ls-remote`.
-string[] fetchTags(string repo) {
-    const cmd = "git ls-remote --tags --refs https://github.com/" ~ repo;
+alias TagRev = Tuple!(string, "tag", string, "rev");
+
+/// Fetches `(tag name, commit hash)` pairs from a GitHub `"owner/repo"`
+/// via `git ls-remote`.
+TagRev[] fetchTags(string repo) {
+    const cmd = "git ls-remote --tags https://github.com/" ~ repo;
     stderr.writefln(`> %s`, cmd);
     const result = executeShell(cmd, null, Config.stderrPassThrough);
     enforce(result.status == 0, "git ls-remote failed: " ~ repo);
     return parseGitLsRemoteTags(result.output);
+}
+
+/// Resolves each requested version to the commit hash its `v<version>`
+/// release tag points to (for fetchers that pin an explicit `rev`).
+string[string] resolveTagRevs(string tagsRepo, const string[] versions) {
+    const tagRevs = fetchTags(tagsRepo);
+    string[string] revs;
+    foreach (ver; versions) {
+        const tag = "v" ~ ver;
+        auto hit = tagRevs.find!(tr => tr.tag == tag);
+        enforce(!hit.empty,
+            "No tag " ~ tag ~ " found in repo " ~ tagsRepo);
+        revs[ver] = hit.front.rev;
+    }
+    return revs;
 }
 
 /// Resolves an inclusive `[first, last]` minor range against the tags of
@@ -172,7 +192,7 @@ string[] resolveVersionRange(Scheme)(string tagsRepo, string first, string last)
     const lo = Scheme.parseLoose(first).value;
 
     auto stable = fetchTags(tagsRepo)
-        .map!(s => Scheme.parseLoose(s))
+        .map!(tr => Scheme.parseLoose(tr.tag))
         .joiner
         .filter!isStable
         .array;
@@ -194,25 +214,36 @@ string[] resolveVersionRange(Scheme)(string tagsRepo, string first, string last)
     return vers.map!(v => v.to!string).array;
 }
 
-/// Pure: parses the output of `git ls-remote --tags [--refs] <url>` into
-/// a list of tag names (with peeled refs removed).
-string[] parseGitLsRemoteTags(string output) @safe pure {
-    return output.splitLines
-        .map!(line => line.strip)
-        .filter!(line => line.length > 0)
-        .map!((line) {
-            const tabIdx = line.indexOf('\t');
-            return tabIdx < 0 ? "" : line[tabIdx + 1 .. $];
-        })
-        .filter!(refName => refName.startsWith("refs/tags/"))
-        .map!(refName => refName["refs/tags/".length .. $])
-        .filter!(name => !name.endsWith("^{}"))
-        .array;
+/// Pure: parses the output of `git ls-remote --tags <url>` into a list of
+/// `(tag name, commit hash)` pairs in output order. A peeled ref
+/// (`name^{}`) carries the commit an annotated tag points to, so it
+/// overwrites the hash of its already-seen `name` entry; lightweight tags
+/// only have the direct entry.
+TagRev[] parseGitLsRemoteTags(string output) @safe pure {
+    TagRev[] tagRevs;
+    foreach (line; output.splitLines.map!(line => line.strip)) {
+        const tabIdx = line.indexOf('\t');
+        if (tabIdx < 0) continue;
+        const hash = line[0 .. tabIdx];
+        const refName = line[tabIdx + 1 .. $];
+        if (!refName.startsWith("refs/tags/")) continue;
+        auto name = refName["refs/tags/".length .. $];
+        if (name.endsWith("^{}")) {
+            name = name[0 .. $ - "^{}".length];
+            const idx = tagRevs.countUntil!(tr => tr.tag == name);
+            if (idx >= 0) tagRevs[idx].rev = hash;
+        } else {
+            tagRevs ~= TagRev(name, hash);
+        }
+    }
+    return tagRevs;
 }
 
 // editorconfig-checker-disable
 unittest {
-    // Mixed peeled / non-peeled, junk lines, non-version tags.
+    // Mixed peeled / non-peeled, junk lines, non-version tags. The peeled
+    // `^{}` hash replaces the annotated tag object's hash; lightweight
+    // tags (no peeled line) keep their direct hash.
     auto sample = outdent(`
         abc123	refs/tags/v1.0.0
         def456	refs/tags/v1.0.0^{}
@@ -220,7 +251,11 @@ unittest {
         000zzz	refs/tags/CI
         aaabbb	refs/heads/main
     `)[1 .. $];
-    assert(parseGitLsRemoteTags(sample) == ["v1.0.0", "v1.1.0", "CI"]);
+    assert(parseGitLsRemoteTags(sample) == [
+        TagRev("v1.0.0", "def456"),
+        TagRev("v1.1.0", "789ghi"),
+        TagRev("CI", "000zzz"),
+    ]);
     assert(parseGitLsRemoteTags("") == []);
 }
 // editorconfig-checker-enable

--- a/src/main.d
+++ b/src/main.d
@@ -42,7 +42,7 @@ void main(string[] args) {
             "component",
                 // Ideally we would generate the list of allowed values as
                 // opposed to this hardcoding
-                "What component to fetch. dmd | dmd_src | ldc | ldc_src, " ~
+                "What component to fetch. dmd | dmd_src | ldc | ldc_src | dub, " ~
                     "default ldc",
                 &component,
             "dry-run",
@@ -68,7 +68,7 @@ void main(string[] args) {
         defaultGetoptFormatter(
             w,
             "dlang-nix-fetcher - " ~
-                "tool for fetching source and binary releases of DMD and LDC",
+                "tool for fetching source and binary releases of DMD, LDC and dub",
             parseCLI(args[0 .. 1]).options,
         );
         return;
@@ -105,6 +105,13 @@ void main(string[] args) {
             ? componentVersions
             : compilerInfo.defaultVersions.dup;
     }
+
+    // Pin the commit each release tag points to, for components whose nix
+    // fetcher takes an explicit `rev` alongside the hash.
+    Hash[Version] revs;
+    if (compilerInfo.resolveRevs !is null)
+        revs = compilerInfo.resolveRevs(
+            compilerInfo.tagsRepo, componentVersions);
 
     const platforms = componentVersions
         .map!(vers => compilerInfo.platforms(vers))
@@ -147,6 +154,9 @@ void main(string[] args) {
     Hash[Platform][Version] hashes;
     foreach (i; 0 .. jobs.length) {
         hashes[jobs[i][0]][jobs[i][1]] = results[i];
+    }
+    foreach (compilerVersion, rev; revs) {
+        hashes[compilerVersion]["rev"] = rev;
     }
 
     if (!liveRun) {


### PR DESCRIPTION
## Summary

Three related changes that extend dub support end to end:

- **`feat(fetcher): add support for dub`** — the fetcher now maintains `pkgs/dub/supported-source-versions.json` (previously hand-edited). The new `dub` component records the commit each release tag points to (`rev`), with `fetchTags` reworked to return (tag, commit) pairs including peeled annotated tags.
- **`feat(pkgs/dmd): backfill source releases 1.0.0–1.41.0`** — dub source version backfill produced by the fetcher.
- **`feat(pkgs/dub): add per-version d-compiler option and fix build matrix`** — dub packages follow dmd's `host-d-compiler` pattern: an optional `"d-compiler"` key in `supported-source-versions.json` selects the host compiler from this project's package catalog, defaulting to `config.packages.ldc` (`ldc-1_42_0`) instead of nixpkgs' LDC.

## Build matrix (verified by building every version)

| Versions | Status |
|---|---|
| 1.0.0–1.6.0 | `build = false` — `postPatch` fails (`test/fetchzip.sh` doesn't exist yet) |
| 1.7.2–1.19.0 | `build = false` — predate the `build.d` build script |
| 1.20.1–1.23.0 | ✅ resurrected via `d-compiler = ldc-binary-1_28_0` (they use `std.xml`, removed from newer Phobos) |
| 1.24.1–1.29.2 | ✅ builds + tests pass (skip-list coverage extended down from 1.30.0) |
| 1.30.0 | ✅ pinned to `ldc-binary-1_28_0`: frontends ≥ 2.111 reject its `semver.d` (`in` contract may throw in `nothrow` function; fixed in dub 1.31), and ldc-binary 1.39.0/1.40.1 segfault on macOS 26 arm64 |
| 1.31.1–1.43.0-alpha | ✅ builds + tests pass with the default `ldc-1_42_0` |

`skippedTests` is now system-aware: `cache-generated-test-config.sh` (BSD `stat` flags) is skipped on darwin before 1.25.0; `dc-env.sh` / `removed-dub-obj.sh` are skipped before 1.25.0 everywhere; the `use-c-sources`/`pr264x`/`issue2698` skips now start at 1.33.0 where those tests were introduced.

## Test plan

- [x] All 24 buildable dub versions built with `nix build` (including test suites) on x86_64-linux
- [x] All 24 buildable dub versions built on aarch64-darwin (macOS 26.3, arm64)
- [x] `nix eval` checks: dmd/ldc packages unaffected by the `callWithExtras` change; `lib.allowedToFailMap` reflects the new build flags