### PR TITLE
fix(pkgs): fix compatibility with upgraded Nixpkgs channel inputs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,5 +4,7 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.1.1; then
 fi
 
 dotenv_if_exists
-watch_file shell.nix
-use flake
+
+watch_file "$(find ./shells/ -name "*.nix" -printf '"%p" ')"
+
+use flake ".#${DEV_SHELL:-default}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,8 @@ jobs:
       fail-fast: false
       matrix: ${{fromJSON(needs.generate-matrix.outputs.matrix)}}
 
-    name: ${{ matrix.package }} | ${{ matrix.system }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allowedToFail }}
 
     steps:
       - uses: actions/checkout@v7
@@ -65,8 +64,11 @@ jobs:
           name: ${{ vars.CACHIX_CACHE }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build ${{ matrix.package }}
-        run: nix build -L --json --no-link '.#packages.${{ matrix.attrPath }}'
+      # A job may build several packages (small ones are batched together by
+      # `dlang-nix-fetcher ci plan-matrix`). `--keep-going` so one failure still
+      # builds & caches the rest of the batch; the job still fails if any did.
+      - name: Build
+        run: nix build -L --no-link --keep-going ${{ matrix.installables }}
 
   results:
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-compat": {
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748821116,
-        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,6 +5,7 @@
     dc = import ./dc.nix { inherit lib; };
     inherit (import ./mk-gh-actions-matrix.nix { inherit self lib; })
       allowedToFailMap
+      doCheckMap
       nixSystemToGHPlatform
       ;
     versionUtils = import ./version-utils.nix { };

--- a/lib/mk-gh-actions-matrix.nix
+++ b/lib/mk-gh-actions-matrix.nix
@@ -17,6 +17,16 @@ rec {
     ))
   ];
 
+  # `{ package -> { system -> doCheck } }`, consumed by `dlang-nix-fetcher ci
+  # plan-matrix` to weight each package (test-running builds are heavier than
+  # build-only ones).
+  doCheckMap = lib.pipe (mkGHActionsMatrix.include) [
+    (builtins.groupBy (p: p.package))
+    (builtins.mapAttrs (
+      n: v: builtins.mapAttrs (s: ps: (builtins.head ps).doCheck) (builtins.groupBy (p: p.system) v)
+    ))
+  ];
+
   mkGHActionsMatrix = {
     include = lib.pipe (builtins.attrNames nixSystemToGHPlatform) [
       (builtins.concatMap (
@@ -33,6 +43,7 @@ rec {
             os = platform;
             allowedToFail =
               !(p.passthru.buildStatus or (throw "${package} does not expose build status")).build;
+            doCheck = p.doCheck or false;
             inherit system package;
             attrPath = "packages.${system}.${lib.strings.escapeNixIdentifier package}";
           }

--- a/lib/version-catalog.nix
+++ b/lib/version-catalog.nix
@@ -25,7 +25,6 @@ let
       extraArgs = {
         hostDCompiler = result'.hostDCompiler or self'.packages.ldc-bootstrap;
         dCompiler = result'.dCompiler or self'.packages.ldc;
-        inherit (pkgs.darwin.apple_sdk.frameworks) Foundation;
       };
       result' = callPackage package (lib.intersectAttrs (lib.functionArgs package) extraArgs);
     in

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18,29 +18,28 @@ in
         // (genPkgVersions "ldc").hierarchical
         // (genPkgVersions "dub").hierarchical;
 
-      packages =
-        {
-          # NOTE: This is only the default. The bootstrap compiler in the
-          # version catalog will override this.
-          ldc-bootstrap = self'.packages."ldc-binary-1_42_0";
-          ldc = self'.packages."ldc-1_42_0";
+      packages = {
+        # NOTE: This is only the default. The bootstrap compiler in the
+        # version catalog will override this.
+        ldc-bootstrap = self'.packages."ldc-binary-1_42_0";
+        ldc = self'.packages."ldc-1_42_0";
 
-          # DUB is released alongside DMD. When DMD 2.112.0 shipped, upstream
-          # appears to have forgotten to bump DUB from 1.42.0-beta.1 to the
-          # final 1.42.0 tag, so the newest released DUB is still this beta.
-          # Switch to "dub-1_42_0" once upstream tags the stable release.
-          dub = self'.packages."dub-1_42_0-beta_1";
+        # DUB is released alongside DMD. When DMD 2.112.0 shipped, upstream
+        # appears to have forgotten to bump DUB from 1.42.0-beta.1 to the
+        # final 1.42.0 tag, so the newest released DUB is still this beta.
+        # Switch to "dub-1_42_0" once upstream tags the stable release.
+        dub = self'.packages."dub-1_42_0-beta_1";
+      }
+      // (genPkgVersions "ldc").flattened "binary"
+      // (genPkgVersions "ldc").flattened "source"
+      // (genPkgVersions "dub").flattened "source"
+      // optionalAttrs pkgs.hostPlatform.isx86 (
+        {
+          dmd-bootstrap = self'.packages."dmd-binary-2_098_0";
+          dmd = self'.packages."dmd-2_112_0";
         }
-        // (genPkgVersions "ldc").flattened "binary"
-        // (genPkgVersions "ldc").flattened "source"
-        // (genPkgVersions "dub").flattened "source"
-        // optionalAttrs pkgs.hostPlatform.isx86 (
-          {
-            dmd-bootstrap = self'.packages."dmd-binary-2_098_0";
-            dmd = self'.packages."dmd-2_112_0";
-          }
-          // (genPkgVersions "dmd").flattened "binary"
-          // (genPkgVersions "dmd").flattened "source"
-        );
+        // (genPkgVersions "dmd").flattened "binary"
+        // (genPkgVersions "dmd").flattened "source"
+      );
     };
 }

--- a/pkgs/dlang-nix-fetcher/default.nix
+++ b/pkgs/dlang-nix-fetcher/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDubPackage,
+}:
+# The repo's `dlang-nix-fetcher` D tool: prefetches DMD/LDC/dub releases and,
+# via the `ci` subcommand, packs the CI build matrix. Packaged so the
+# matrix-generation step (`scripts/ci-matrix.sh`) can call `dlang-nix-fetcher ci
+# plan-matrix` from the `.#ci` dev shell without a `dub build` on the hot path.
+# Built with the nixpkgs LDC (not the repo's own, to avoid a build cycle).
+buildDubPackage {
+  pname = "dlang-nix-fetcher";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../..;
+    fileset = lib.fileset.unions [
+      ../../dub.sdl
+      ../../dub.selections.json
+      ../../src
+    ];
+  };
+
+  dubLock = ./dub-lock.json;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/dlang-nix-fetcher "$out/bin/dlang-nix-fetcher"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fetches DMD/LDC/dub releases and packs the dlang.nix CI build matrix";
+    mainProgram = "dlang-nix-fetcher";
+  };
+}

--- a/pkgs/dlang-nix-fetcher/dub-lock.json
+++ b/pkgs/dlang-nix-fetcher/dub-lock.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "expected": {
+      "version": "0.4.1",
+      "sha256": "1ahr7gbjl6dgw1qs9x5yzcwhbzfg7ygdlsm9gw4hgmm1xrfcpri0"
+    },
+    "semver": {
+      "version": "0.5.0",
+      "sha256": "06w7yg5r6xpy8ypykwhzjif5z2fj3jrjzqkzyvrbpih4pgxg5hmg"
+    },
+    "silly": {
+      "version": "1.1.1",
+      "sha256": "0fz7ib715sfk3w69i6xns5pwd4caahvfqjf32v13daxm1ms8xdzz"
+    },
+    "sparkles": {
+      "version": "0.4.0",
+      "sha256": "10dvrqrfw3ckvvdzazy32ys2f3wyv2ri4y414z44rnfdv9nlx93w"
+    }
+  }
+}

--- a/pkgs/dmd/binary.nix
+++ b/pkgs/dmd/binary.nix
@@ -40,13 +40,12 @@ stdenv.mkDerivation {
     lib.optional hostPlatform.isLinux autoPatchelfHook
     ++ lib.optional hostPlatform.isDarwin fixDarwinDylibNames;
 
-  propagatedBuildInputs =
-    [
-      curl
-      tzdata
-    ]
-    ++ (lib.optional hostPlatform.isLinux gccForLibs.libgcc)
-    ++ (lib.optional (lib.versionOlder version "2.084.0") stdenv.cc.cc.lib);
+  propagatedBuildInputs = [
+    curl
+    tzdata
+  ]
+  ++ (lib.optional hostPlatform.isLinux gccForLibs.libgcc)
+  ++ (lib.optional (lib.versionOlder version "2.084.0") stdenv.cc.cc.lib);
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/dmd/build-status.nix
+++ b/pkgs/dmd/build-status.nix
@@ -38,6 +38,26 @@ let
       else
         "${dmdTestDir}/runnable";
 
+    # C++ interop / mangling tests. These exercise the C++ ABI, so we want them
+    # running on x86_64-linux (the only platform where dmd `check` is currently
+    # enabled). They are only skipped on darwin for now, where the toolchain
+    # still trips over them; they should be enabled there too once the macOS
+    # runner situation is sorted out.
+    cxxSkippedTests = [
+      "${cxxTestDir}/cpp11.d"
+      "${cxxTestDir}/cpp_stdlib.d"
+      "${cxxTestDir}/cppa.d"
+      "${cxxTestDir}/externmangle2.d"
+      "${cxxTestDir}/cpp_abi_tests.d"
+      "${cxxTestDir}/externmangle.d"
+      "${dmdTestDir}/dshell/dll_cxx.d"
+    ]
+    ++ lib.optionals (versionBetween "2.099.0" latestVersion version) [
+      "${cxxTestDir}/test22287.d"
+      "${cxxTestDir}/test7925.d"
+    ]
+    ++ lib.optionals (versionBetween "2.101.0" latestVersion version) [ "${cxxTestDir}/test23135.d" ];
+
     skippedTests = [
       # Tests that rely on the time of build
       "${dmdTestDir}/compilable/ddocYear.d"
@@ -76,20 +96,7 @@ let
       let
         tests =
           skippedTests
-          ++ [
-            "${cxxTestDir}/cpp11.d"
-            "${cxxTestDir}/cpp_stdlib.d"
-            "${cxxTestDir}/cppa.d"
-            "${cxxTestDir}/externmangle2.d"
-            "${cxxTestDir}/cpp_abi_tests.d"
-            "${cxxTestDir}/externmangle.d"
-            "${dmdTestDir}/dshell/dll_cxx.d"
-          ]
-          ++ lib.optionals (versionBetween "2.099.0" latestVersion version) [
-            "${cxxTestDir}/test22287.d"
-            "${cxxTestDir}/test7925.d"
-          ]
-          ++ lib.optionals (versionBetween "2.101.0" latestVersion version) [ "${cxxTestDir}/test23135.d" ]
+          ++ cxxSkippedTests
           ++ (
             if versionBetween "2.092.1" "2.098.1" version then
               if versionBetween "2.092.1" "2.097.2" version then

--- a/pkgs/dmd/build-status.nix
+++ b/pkgs/dmd/build-status.nix
@@ -38,40 +38,39 @@ let
       else
         "${dmdTestDir}/runnable";
 
-    skippedTests =
-      [
-        # Tests that rely on the time of build
-        "${dmdTestDir}/compilable/ddocYear.d"
+    skippedTests = [
+      # Tests that rely on the time of build
+      "${dmdTestDir}/compilable/ddocYear.d"
 
-        # GDB tests
-        "${dmdTestDir}/runnable/gdb1.d"
-        "${dmdTestDir}/runnable/gdb10311.d"
-        "${dmdTestDir}/runnable/gdb14225.d"
-        "${dmdTestDir}/runnable/gdb14276.d"
-        "${dmdTestDir}/runnable/gdb14313.d"
-        "${dmdTestDir}/runnable/gdb14330.d"
-        "${dmdTestDir}/runnable/gdb15729.sh"
-        "${dmdTestDir}/runnable/gdb4149.d"
-        "${dmdTestDir}/runnable/gdb4181.d"
-      ]
-      # tests that rely on objdump whitespace
-      ++ (
-        if versionAtLeast version "2.087.0" then
-          [
-            "${dmdTestDir}/runnable/cdvecfill.sh"
-            "${dmdTestDir}/compilable/cdcmp.d"
-          ]
-        else
-          [
-            "${dmdTestDir}/runnable/test_cdvecfill.d"
-            "${dmdTestDir}/runnable/test_cdcmp.d"
-          ]
-      )
+      # GDB tests
+      "${dmdTestDir}/runnable/gdb1.d"
+      "${dmdTestDir}/runnable/gdb10311.d"
+      "${dmdTestDir}/runnable/gdb14225.d"
+      "${dmdTestDir}/runnable/gdb14276.d"
+      "${dmdTestDir}/runnable/gdb14313.d"
+      "${dmdTestDir}/runnable/gdb14330.d"
+      "${dmdTestDir}/runnable/gdb15729.sh"
+      "${dmdTestDir}/runnable/gdb4149.d"
+      "${dmdTestDir}/runnable/gdb4181.d"
+    ]
+    # tests that rely on objdump whitespace
+    ++ (
+      if versionAtLeast version "2.087.0" then
+        [
+          "${dmdTestDir}/runnable/cdvecfill.sh"
+          "${dmdTestDir}/compilable/cdcmp.d"
+        ]
+      else
+        [
+          "${dmdTestDir}/runnable/test_cdvecfill.d"
+          "${dmdTestDir}/runnable/test_cdcmp.d"
+        ]
+    )
 
-      ++ lib.optionals (versionBetween "2.089.0" "2.092.2" version) [ "${dmdTestDir}/dshell/test6952.d" ]
-      # This test is patched on it's current path, but would have to patch
-      # the patch to work on the file path before repository unification.
-      ++ lib.optionals (hasDruntimeRepo) [ "${dmdTestDir}/fail_compilation/needspkgmod.d" ];
+    ++ lib.optionals (versionBetween "2.089.0" "2.092.2" version) [ "${dmdTestDir}/dshell/test6952.d" ]
+    # This test is patched on it's current path, but would have to patch
+    # the patch to work on the file path before repository unification.
+    ++ lib.optionals (hasDruntimeRepo) [ "${dmdTestDir}/fail_compilation/needspkgmod.d" ];
 
     darwinSkippedTests =
       let

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -24,8 +24,6 @@
   curl,
   tzdata,
   gdb,
-  gcc11,
-  Foundation,
   targetPackages,
   fetchpatch,
   bash,
@@ -88,7 +86,7 @@ let
     [
       "SHELL=${bash}/bin/bash"
       "DMD=$(NIX_BUILD_TOP)/dmd/${buildPath}/dmd"
-      "CC=${if stdenv.isDarwin then stdenv.cc else gcc11}/bin/cc"
+      "CC=${stdenv.cc}/bin/cc"
       "HOST_DMD=${hostDCInfo.dmdWrapper}"
       "PIC=1"
       "BUILD=${buildMode}"
@@ -377,7 +375,6 @@ stdenv.mkDerivation rec {
     tzdata
   ]
   ++ lib.optionals stdenv.isDarwin [
-    Foundation
     # Exports MACOSX_DEPLOYMENT_TARGET for every build/check phase. Covers the
     # compiler invocations the druntime/phobos makefiles don't drive (building
     # dmd itself, the test harness) — without it DMD's codegen falls back to its
@@ -411,8 +408,6 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = buildStatus.check;
-
-  checkInputs = lib.optional stdenv.isDarwin Foundation;
 
   checkFlagsMake = commonBuildFlags { forMake = true; } ++ [ "N=$(checkJobs)" ];
   checkFlagsRunD = commonBuildFlags { forMake = false; };

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -115,39 +115,38 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  srcs =
-    [
-      (fetchFromGitHub {
-        owner = "dlang";
-        repo = "dmd";
-        rev = "v${version}";
-        sha256 = dmdSha256;
-        name = "dmd";
-      })
-      (fetchFromGitHub {
-        owner = "dlang";
-        repo = "phobos";
-        rev = "v${version}";
-        sha256 = phobosSha256;
-        name = "phobos";
-      })
-      (fetchFromGitHub {
-        owner = "dlang";
-        repo = "tools";
-        rev = "v${version}";
-        sha256 = toolsSha256;
-        name = "tools";
-      })
-    ]
-    ++ lib.optionals druntimeRepo [
-      (fetchFromGitHub {
-        owner = "dlang";
-        repo = "druntime";
-        rev = "v${version}";
-        sha256 = druntimeSha256;
-        name = "druntime";
-      })
-    ];
+  srcs = [
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "dmd";
+      rev = "v${version}";
+      sha256 = dmdSha256;
+      name = "dmd";
+    })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "phobos";
+      rev = "v${version}";
+      sha256 = phobosSha256;
+      name = "phobos";
+    })
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "tools";
+      rev = "v${version}";
+      sha256 = toolsSha256;
+      name = "tools";
+    })
+  ]
+  ++ lib.optionals druntimeRepo [
+    (fetchFromGitHub {
+      owner = "dlang";
+      repo = "druntime";
+      rev = "v${version}";
+      sha256 = druntimeSha256;
+      name = "druntime";
+    })
+  ];
 
   sourceRoot = ".";
 
@@ -370,21 +369,21 @@ stdenv.mkDerivation rec {
     makeWrapper
     which
     installShellFiles
-  ] ++ lib.optional (lib.versionOlder version "2.088.0") git;
+  ]
+  ++ lib.optional (lib.versionOlder version "2.088.0") git;
 
-  buildInputs =
-    [
-      curl
-      tzdata
-    ]
-    ++ lib.optionals stdenv.isDarwin [
-      Foundation
-      # Exports MACOSX_DEPLOYMENT_TARGET for every build/check phase. Covers the
-      # compiler invocations the druntime/phobos makefiles don't drive (building
-      # dmd itself, the test harness) — without it DMD's codegen falls back to its
-      # hardcoded 10.9 default (compiler/src/dmd/backend/machobj.d).
-      (darwinMinVersionHook darwinTarget)
-    ];
+  buildInputs = [
+    curl
+    tzdata
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    Foundation
+    # Exports MACOSX_DEPLOYMENT_TARGET for every build/check phase. Covers the
+    # compiler invocations the druntime/phobos makefiles don't drive (building
+    # dmd itself, the test harness) — without it DMD's codegen falls back to its
+    # hardcoded 10.9 default (compiler/src/dmd/backend/machobj.d).
+    (darwinMinVersionHook darwinTarget)
+  ];
 
   nativeCheckInputs = [ gdb ] ++ lib.optional (lib.versionOlder version "2.089.0") unzip;
 

--- a/pkgs/dub/build-status.nix
+++ b/pkgs/dub/build-status.nix
@@ -158,16 +158,20 @@ let
     );
 in
 mergeVersions [
-  # dub <= 1.19.0 cannot be built with the current packaging:
-  # - 1.0.0 - 1.6.0: postPatch fails (test/fetchzip.sh does not exist yet)
-  # - 1.7.2 - 1.19.0: pre-build.d build system (no ./build.d)
+  # dub <= 1.19.0 use the pre-`build.d` build system (`./build.sh`) and are
+  # compiled with an era-matched `ldc-binary-1_N_*` host pinned via `d-compiler`
+  # in supported-source-versions.json (a modern host compiler rejects their
+  # source). Only x86_64-linux is enabled: those vintage LDC releases only ship
+  # x86_64 binaries (no aarch64 / i686), and the old macOS bootstrap binaries
+  # segfault on the current macOS runner. Their legacy test suites also predate
+  # the current `run-unittest.sh` harness, so `check` is left off.
   (between "1.0.0" "1.19.0" (
     _version:
     listToAttrs (
       map (
         system:
         nameValuePair system {
-          build = false;
+          build = system == "x86_64-linux";
           check = false;
           skippedTests = [ ];
         }

--- a/pkgs/dub/default.nix
+++ b/pkgs/dub/default.nix
@@ -19,6 +19,17 @@ let
 
   buildStatus = getBuildStatus "dub" version stdenv.system;
 
+  # Offer this package only on the systems where the build matrix says it
+  # builds. The pre-1.20 releases pin vintage `ldc-binary` hosts that are only
+  # published for x86_64, so without this they would be surfaced on (and fail to
+  # evaluate on) systems such as aarch64-darwin where no such bootstrap binary
+  # exists.
+  buildPlatforms = lib.attrNames (
+    lib.filterAttrs (_system: status: status.build) (
+      (import ./build-status.nix { inherit lib; }).${version} or { }
+    )
+  );
+
   hostDCInfo = getDCInfo dCompiler;
 in
 stdenv.mkDerivation rec {
@@ -40,12 +51,20 @@ stdenv.mkDerivation rec {
 
   dubvar = "\\$DUB";
   postPatch = ''
-    patchShebangs test
+    patchShebangs .
 
 
     # Can be removed with https://github.com/dlang/dub/pull/1368
-    substituteInPlace test/fetchzip.sh \
-        --replace "dub remove" "\"${dubvar}\" remove"
+    if [ -f test/fetchzip.sh ]; then
+      substituteInPlace test/fetchzip.sh \
+          --replace "dub remove" "\"${dubvar}\" remove"
+    fi
+
+    # Fix a missing comma in dub 1.0.0 that causes implicit string concatenation error
+    ${lib.optionalString (lib.versionOlder version "1.1.0") ''
+      substituteInPlace source/dub/commandline.d \
+          --replace '"This command will convert between JSON and SDLang formatted package recipe files."' '"This command will convert between JSON and SDLang formatted package recipe files.",'
+    ''}
   '';
 
   nativeBuildInputs = [
@@ -67,8 +86,18 @@ stdenv.mkDerivation rec {
       exit "Error: could not find D compiler"
     fi
     echo "$dc_ found and used as D compiler to build $pname"
-    $dc ./build.d
-    ./build
+
+    if [ -f ./build.d ]; then
+      $dc ./build.d
+      ./build
+    elif [ -f ./build.sh ]; then
+      export DMD=$dc
+      export GITVER=v${version}
+      ./build.sh ${lib.optionalString stdenv.hostPlatform.isLinux "-L-no-pie"}
+    else
+      echo "Error: no build script found"
+      exit 1
+    fi
   '';
 
   doCheck = buildStatus.check;
@@ -96,12 +125,6 @@ stdenv.mkDerivation rec {
     homepage = "https://code.dlang.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ ThomasMader ];
-    platforms = [
-      "x86_64-linux"
-      "i686-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    platforms = buildPlatforms;
   };
 }

--- a/pkgs/dub/supported-source-versions.json
+++ b/pkgs/dub/supported-source-versions.json
@@ -1,81 +1,101 @@
 {
   "1.0.0": {
+    "d-compiler": "ldc-binary-1_0_0",
     "dub": "sha256-EMpbuZDLQxn/Z9zxO0bKGRNSQ1JEku4kiYPJBCsURR8=",
     "rev": "b59af2b8befb4fad4157d8c9cc86dba707b2fc87"
   },
   "1.1.2": {
+    "d-compiler": "ldc-binary-1_1_1",
     "dub": "sha256-M8/lP7rBYzpF+q8UUHIqp1+3ZAwyQSSjBwwZBqD2v2k=",
     "rev": "6353f43d00dafa775d4bbbbcdebc1682f87bbc6f"
   },
   "1.2.2": {
+    "d-compiler": "ldc-binary-1_2_0",
     "dub": "sha256-zdLAnC4rw3hHC2wcBSgjJd+dkjto6DUEZjXkdlEI8LE=",
     "rev": "4fbb1280f0e5d5848bce23a4a0ee6e5d7ffff337"
   },
   "1.3.0": {
+    "d-compiler": "ldc-binary-1_3_0",
     "dub": "sha256-HGbao/MLsyGB6/Txc15kk+moi3oqFE7GWcdoDcFGgnw=",
     "rev": "907c3cae18054ac088cdc2d0a094d0e6a49b06d8"
   },
   "1.4.1": {
+    "d-compiler": "ldc-binary-1_4_0",
     "dub": "sha256-1wkO6dXXxFqG6Zw5TP0EH6EouhRKq1hF15D0o7NW/Uw=",
     "rev": "029ed323555c1f1770314a2b9a8d28cc8f165030"
   },
   "1.5.0": {
+    "d-compiler": "ldc-binary-1_5_0",
     "dub": "sha256-BW8j58NODenBFd7u27xqH433LMTcVty4zPFDGUnPsU4=",
     "rev": "9464a576b2734ec56a476b507db3ecb1c66081a8"
   },
   "1.6.0": {
+    "d-compiler": "ldc-binary-1_6_0",
     "dub": "sha256-85/68o/OGHtNlMN4H5P8E+ADlw++ZwVJY4sOI+4tWfY=",
     "rev": "5f4fe50599da1f5853e6313fd99a0f11f121b766"
   },
   "1.7.2": {
+    "d-compiler": "ldc-binary-1_7_0",
     "dub": "sha256-iZulAWv7cRZ37ZaksAa055jrc9oqSx80ZvC+UN9ecRw=",
     "rev": "208d4f059b7effcedef4ccd4393494e4010e7d16"
   },
   "1.8.1": {
+    "d-compiler": "ldc-binary-1_8_0",
     "dub": "sha256-pinnY8lSIzOII/lCOde+0plcPZK8Gr21lq5spyXpJ5s=",
     "rev": "02cc679762d0cfd3e9f833c8b0a1d71b1f06b37b"
   },
   "1.9.0": {
+    "d-compiler": "ldc-binary-1_9_0",
     "dub": "sha256-PrOtBE2zpX1XMEeAYly0zGmChR1C+Me40GC9SI9pCYk=",
     "rev": "ddf6601ecfb5f2fa9d2b0d4d23281941dca26c5f"
   },
   "1.10.0": {
+    "d-compiler": "ldc-binary-1_10_0",
     "dub": "sha256-xI7QvXP4bz3UfSnWX4z2wsA16C5wg88XlkcQLZm7vQs=",
     "rev": "6b0cdc0288e14c81725af0421f589e9c88df6cea"
   },
   "1.11.0": {
+    "d-compiler": "ldc-binary-1_11_0",
     "dub": "sha256-998kBnG64FNR5AMS4xPemFVbfWaT+1SxhcUqbt9M5tI=",
     "rev": "9065964db9d8e1cf35aff53cb8c16417a754e005"
   },
   "1.12.1": {
+    "d-compiler": "ldc-binary-1_12_0",
     "dub": "sha256-ShT1vDy5GGoNw+7WiptSx/HWsDZyN8i9wbC71zcyiWA=",
     "rev": "6963c4645e727f19b79d8e9620befa24e16851f2"
   },
   "1.13.0": {
+    "d-compiler": "ldc-binary-1_13_0",
     "dub": "sha256-G8ufBIu+JS2eCOtZJT0j+iLxI+AIhbfWGNIptWy7pfE=",
     "rev": "41d1c11bc34d247b1c73b124c90b19bb6a47c0ad"
   },
   "1.14.0": {
+    "d-compiler": "ldc-binary-1_14_0",
     "dub": "sha256-BLlb2TTrSvXazKuqwEuipwMmCCrIMbhg8Cjlmf10Exw=",
     "rev": "05ec4f664d8a626a63d74a0b129a6bb7b38f89d4"
   },
   "1.15.0": {
+    "d-compiler": "ldc-binary-1_15_0",
     "dub": "sha256-u9AvPL/zapMZ3mV4kXjo+tFzUSFNQ5f0oIErndLwKq0=",
     "rev": "5307c86b4916c3dd32c2143475e2b49b56578a1a"
   },
   "1.16.0": {
+    "d-compiler": "ldc-binary-1_16_0",
     "dub": "sha256-fECfb4AgkGcVo/SlcNEfwIQadnIBcJiS7l4fmgnssHE=",
     "rev": "6c8fbaea6ee9d179898166a03727b88e3f91cdf0"
   },
   "1.17.0": {
+    "d-compiler": "ldc-binary-1_17_0",
     "dub": "sha256-7ZXWMvVIypZRE+TQcwBWMMR2G6FAC31zSy3IPZks2mM=",
     "rev": "5815b06d0ef2b30b0746d5ceb3070ac81ae8169c"
   },
   "1.18.0": {
+    "d-compiler": "ldc-binary-1_18_0",
     "dub": "sha256-KE9ku24VG0IaPFI38Y10TvRGzmYI/A2SIgNltAP9uO0=",
     "rev": "2c5e115646cfda4a4496ae8ecd189ed992fece94"
   },
   "1.19.0": {
+    "d-compiler": "ldc-binary-1_19_0",
     "dub": "sha256-se2tm7K2V18kXw4qQItq8CBbBF+uL6VFTk0NGE/8ARo=",
     "rev": "08ebe85e154dfedcc8ac21fb96bef30beb956209"
   },

--- a/pkgs/ldc/binary.nix
+++ b/pkgs/ldc/binary.nix
@@ -8,6 +8,7 @@
   autoPatchelfHook,
   fixDarwinDylibNames,
   libxml2,
+  runCommand,
   ...
 }:
 let
@@ -45,6 +46,21 @@ let
   tarballSuffix = if hostPlatform.isWindows then "7z" else "tar.xz";
 
   archivePlatform = systemToArchivePlatform."${system}";
+
+  # The pre-built LDC bootstrap binaries are linked against `libxml2.so.2`, but
+  # modern nixpkgs ships libxml2 with a bumped soname (e.g. `libxml2.so.16`), so
+  # autoPatchelfHook cannot satisfy the old `NEEDED libxml2.so.2` entry. libxml2
+  # is only pulled in for a handful of LLVM XML helpers that LDC does not
+  # exercise during bootstrap, so aliasing the new library under the old soname
+  # is safe in practice. Resolve to the real versioned file (rather than the
+  # unversioned `libxml2.so` dev symlink) so this keeps working regardless of
+  # where nixpkgs places the unversioned symlink.
+  libxml2Shim = runCommand "libxml2-shim" { } ''
+    mkdir -p $out/lib
+    real=$(readlink -f ${libxml2.out}/lib/libxml2.so)
+    ln -s "$real" $out/lib/libxml2.so.2
+    ln -s "$real" $out/lib/libxml2.so
+  '';
 in
 stdenv.mkDerivation {
   pname = "ldc-binary";
@@ -68,7 +84,7 @@ stdenv.mkDerivation {
     ++ lib.optional hostPlatform.isDarwin fixDarwinDylibNames;
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    libxml2
+    libxml2Shim
     stdenv.cc.cc
   ];
 

--- a/pkgs/ldc/generic.nix
+++ b/pkgs/ldc/generic.nix
@@ -7,7 +7,6 @@
   fetchurl,
   cmake,
   ninja,
-  llvmPackages_12,
   llvmPackages_18,
   curl,
   tzdata,
@@ -15,7 +14,6 @@
   lit,
   gdb,
   unzip,
-  darwin,
   xar,
   bash,
   pkg-config,
@@ -31,8 +29,17 @@ let
   buildStatus = getBuildStatus "ldc" version stdenv.system;
 
   # LDC tracks LLVM closely: 1.30 builds against LLVM 12, the 1.4x line needs
-  # LLVM 15-20 (nixpkgs ships 1.40.1 on LLVM 18, so we use 18 here too).
-  llvmPackages = if lib.versionAtLeast version "1.41.0" then llvmPackages_18 else llvmPackages_12;
+  # LLVM 15-20 (nixpkgs ships 1.40.1 on LLVM 18, so we use 18 here too). The
+  # LLVM 12 set comes from a pinned older nixpkgs (see ../llvm-packages.nix).
+  ourLlvmPackages = import ../llvm-packages.nix {
+    inherit (stdenv) system;
+    inherit llvmPackages_18;
+  };
+  llvmPackages =
+    if lib.versionAtLeast version "1.41.0" then
+      ourLlvmPackages.llvmPackages_18
+    else
+      ourLlvmPackages.llvmPackages_12;
 
   pathConfig = runCommand "phobos-tzdata-curl-paths" { } ''
     mkdir $out
@@ -149,7 +156,6 @@ stdenv.mkDerivation rec {
     unzip
     pkg-config
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation
   # https://github.com/NixOS/nixpkgs/pull/36378#issuecomment-385034818
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) gdb;
 
@@ -180,6 +186,7 @@ stdenv.mkDerivation rec {
       ];
     in
     [
+      "-D CMAKE_POLICY_VERSION_MINIMUM=3.5"
       "-D D_FLAGS=${lib.concatStringsSep ";" dFlags}"
       "-D CMAKE_BUILD_TYPE=Release"
       "-D MULTILIB=OFF"

--- a/pkgs/ldc/generic.nix
+++ b/pkgs/ldc/generic.nix
@@ -88,26 +88,25 @@ stdenv.mkDerivation rec {
   # https://issues.dlang.org/show_bug.cgi?id=19553
   hardeningDisable = [ "fortify" ];
 
-  postUnpack =
-    ''
-      patchShebangs .
-    ''
-    # The remaining steps only massage the bundled dmd test suite, so they are
-    # only needed when we actually run it. The paths below assume the pre-1.41
-    # layout (`tests/d2/dmd-testsuite/`), which LDC 1.42 relocated to
-    # `tests/dmd/`.
-    + lib.optionalString buildStatus.check ''
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/xtest46_gc.d
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/testptrref_gc.d
+  postUnpack = ''
+    patchShebangs .
+  ''
+  # The remaining steps only massage the bundled dmd test suite, so they are
+  # only needed when we actually run it. The paths below assume the pre-1.41
+  # layout (`tests/d2/dmd-testsuite/`), which LDC 1.42 relocated to
+  # `tests/dmd/`.
+  + lib.optionalString buildStatus.check ''
+    rm ldc-${version}-src/tests/d2/dmd-testsuite/fail_compilation/mixin_gc.d
+    rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/xtest46_gc.d
+    rm ldc-${version}-src/tests/d2/dmd-testsuite/runnable/testptrref_gc.d
 
-      # test depends on current year
-      rm ldc-${version}-src/tests/d2/dmd-testsuite/compilable/ddocYear.d
-    ''
-    + lib.optionalString (buildStatus.check && stdenv.hostPlatform.isDarwin) ''
-      # https://github.com/NixOS/nixpkgs/issues/34817
-      rm -r ldc-${version}-src/tests/plugins/addFuncEntryCall
-    '';
+    # test depends on current year
+    rm ldc-${version}-src/tests/d2/dmd-testsuite/compilable/ddocYear.d
+  ''
+  + lib.optionalString (buildStatus.check && stdenv.hostPlatform.isDarwin) ''
+    # https://github.com/NixOS/nixpkgs/issues/34817
+    rm -r ldc-${version}-src/tests/plugins/addFuncEntryCall
+  '';
 
   patches = lib.optionals (versionBetween "2.092.0" "2.101.0" version) [
     # `src/dmd/backend/cg.d` and `src/dmd/backend/var.d` contained arrays defined as
@@ -138,31 +137,29 @@ stdenv.mkDerivation rec {
     ''
   );
 
-  nativeBuildInputs =
-    [
-      cmake
-      hostDCompiler
-      lit
-      lit.python
-      llvmPackages.llvm.dev
-      llvmPackages.lld.dev
-      makeWrapper
-      ninja
-      unzip
-      pkg-config
-    ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation
-    # https://github.com/NixOS/nixpkgs/pull/36378#issuecomment-385034818
-    ++ lib.optional (!stdenv.hostPlatform.isDarwin) gdb;
+  nativeBuildInputs = [
+    cmake
+    hostDCompiler
+    lit
+    lit.python
+    llvmPackages.llvm.dev
+    llvmPackages.lld.dev
+    makeWrapper
+    ninja
+    unzip
+    pkg-config
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation
+  # https://github.com/NixOS/nixpkgs/pull/36378#issuecomment-385034818
+  ++ lib.optional (!stdenv.hostPlatform.isDarwin) gdb;
 
-  buildInputs =
-    [
-      curl
-      tzdata
-    ]
-    # LLVM >= 18 reports `-lxar` in its system libs on macOS, and with
-    # LDC_LINK_MANUALLY=ON the linker needs libxar on its search path.
-    ++ lib.optional (stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "1.41.0") xar;
+  buildInputs = [
+    curl
+    tzdata
+  ]
+  # LLVM >= 18 reports `-lxar` in its system libs on macOS, and with
+  # LDC_LINK_MANUALLY=ON the linker needs libxar on its search path.
+  ++ lib.optional (stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "1.41.0") xar;
 
   cmakeFlags =
     let
@@ -171,17 +168,16 @@ stdenv.mkDerivation rec {
       # LDC 1.42 compiler when it compiles the runtime on aarch64-darwin, so
       # the runtime there is built without LTO.
       useLto = !stdenv.hostPlatform.isDarwin;
-      dFlags =
-        [
-          "-d-version=TZDatabaseDir"
-          "-d-version=LibcurlPath"
-          "-J${pathConfig}"
-          "-O"
-        ]
-        ++ lib.optional (!stdenv.hostPlatform.isDarwin) "-linker=gold"
-        ++ [
-          "-defaultlib=${if useLto then "phobos2-ldc-lto,druntime-ldc-lto" else "phobos2-ldc,druntime-ldc"}"
-        ];
+      dFlags = [
+        "-d-version=TZDatabaseDir"
+        "-d-version=LibcurlPath"
+        "-J${pathConfig}"
+        "-O"
+      ]
+      ++ lib.optional (!stdenv.hostPlatform.isDarwin) "-linker=gold"
+      ++ [
+        "-defaultlib=${if useLto then "phobos2-ldc-lto,druntime-ldc-lto" else "phobos2-ldc,druntime-ldc"}"
+      ];
     in
     [
       "-D D_FLAGS=${lib.concatStringsSep ";" dFlags}"
@@ -228,7 +224,7 @@ stdenv.mkDerivation rec {
 
   checkPhase =
     (lib.optionalString (buildStatus.skippedTests != [ ]) (
-      lib.concatMapStringsSep "\n" (test: ''rm -v ${test}'') buildStatus.skippedTests
+      lib.concatMapStringsSep "\n" (test: "rm -v ${test}") buildStatus.skippedTests
     ))
     + ''
       # Build default lib test runners

--- a/pkgs/llvm-packages.nix
+++ b/pkgs/llvm-packages.nix
@@ -1,0 +1,40 @@
+# A combined view of the `llvmPackages_*` sets the D compilers build against.
+#
+# Most LLVM releases come straight from the flake's pinned nixpkgs (passed in
+# as e.g. `llvmPackages_18`). Older releases that have since been dropped from
+# nixpkgs-unstable are supplied from their own pinned nixpkgs revisions. We
+# only ever consume a single `llvmPackages_*` attribute out of each historical
+# pin, so they are fetched here rather than threaded through the flake inputs,
+# which keeps them out of the main dependency closure and out of flake.lock.
+{
+  system,
+  # LLVM releases still packaged by the flake's nixpkgs are passed through.
+  llvmPackages_18,
+}:
+let
+  # Import a historical nixpkgs revision purely to borrow an LLVM release it
+  # still packages. `fetchTarball` with a fixed `sha256` is pure, so this stays
+  # eval-cacheable even though it is not tracked by flake.lock.
+  llvmFromPinnedNixpkgs =
+    {
+      rev,
+      sha256,
+      attr,
+    }:
+    (import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+      inherit sha256;
+    }) { inherit system; }).${attr};
+in
+{
+  # LDC <= 1.40 builds against LLVM 12, which was removed from nixpkgs-unstable.
+  # Borrow it from the last nixpkgs revision that still shipped it.
+  llvmPackages_12 = llvmFromPinnedNixpkgs {
+    rev = "b134951a4c9f3c995fd7be05f3243f8ecd65d798";
+    sha256 = "0zydsqiaz8qi4zd63zsb2gij2p614cgkcaisnk11wjy3nmiq0x1s";
+    attr = "llvmPackages_12";
+  };
+
+  # LDC >= 1.41 builds against LLVM 18, still present in the flake's nixpkgs.
+  inherit llvmPackages_18;
+}

--- a/scripts/ci-build-weights.json
+++ b/scripts/ci-build-weights.json
@@ -1,0 +1,51 @@
+{
+  "aarch64-darwin": {
+    "default": 8,
+    "dub": {
+      "test": 104
+    },
+    "ldc": {
+      "build": 89
+    },
+    "ldc-binary": {
+      "build": 8
+    }
+  },
+  "x86_64-darwin": {
+    "default": 8,
+    "dmd": {
+      "build": 87
+    },
+    "dmd-binary": {
+      "build": 12
+    },
+    "dub": {
+      "test": 210
+    },
+    "ldc": {
+      "build": 152
+    },
+    "ldc-binary": {
+      "build": 8
+    }
+  },
+  "x86_64-linux": {
+    "default": 6,
+    "dmd": {
+      "test": 245
+    },
+    "dmd-binary": {
+      "build": 12
+    },
+    "dub": {
+      "build": 6,
+      "test": 139
+    },
+    "ldc": {
+      "build": 87
+    },
+    "ldc-binary": {
+      "build": 7
+    }
+  }
+}

--- a/scripts/ci-matrix.sh
+++ b/scripts/ci-matrix.sh
@@ -14,19 +14,23 @@ eval_packages_to_json() {
   cachix_url="https://${CACHIX_CACHE}.cachix.org"
 
   nix eval --json .#lib.allowedToFailMap >"${result_dir}/allowed-to-fail.json"
+  nix eval --json .#lib.doCheckMap >"${result_dir}/do-check.json"
   nix eval --json .#lib.nixSystemToGHPlatform >"${result_dir}/system-to-gh-platform.json"
 
   nix_eval_for_all_systems "$flake_attr_pre" "$flake_attr_post" |
-    cat "${result_dir}/allowed-to-fail.json" "${result_dir}/system-to-gh-platform.json" - |
+    cat "${result_dir}/allowed-to-fail.json" "${result_dir}/do-check.json" \
+      "${result_dir}/system-to-gh-platform.json" - |
     jq -sr '
     .[0] as $allowed_to_fail
-    | .[1] as $system_to_gh_platform
-    | .[2:] as $nix_eval_results
+    | .[1] as $do_check
+    | .[2] as $system_to_gh_platform
+    | .[3:] as $nix_eval_results
     | $nix_eval_results
     | map({
       package: .attr,
       attrPath: "\(.system).\(.attr)",
       allowedToFail: $allowed_to_fail[.attr][.system],
+      doCheck: ($do_check[.attr][.system] // false),
       isCached,
       system,
       cache_url: .outputs.out
@@ -38,8 +42,12 @@ eval_packages_to_json() {
 }
 
 save_gh_ci_matrix() {
-  packages_to_build=$(echo "$packages" | jq -c '. | map(select((.isCached | not) and (.allowedToFail | not)))')
-  matrix='{"include":'"$packages_to_build"'}'
+  # Pack the buildable, uncached packages into a job matrix by estimated build
+  # weight (keeps us under GitHub's 256-configuration cap). Packing + filtering
+  # live in the `dlang-nix-fetcher ci` D tool; see src/dlang_nix/ci/.
+  matrix=$(echo "$packages" |
+    jq -c '[ .[] | { attr: .package, system, os, isCached, allowedToFail, doCheck } ]' |
+    dlang-nix-fetcher ci plan-matrix --weights "$root_dir/scripts/ci-build-weights.json")
   filename=''
   if [ "${IS_INITIAL:-true}" = "true" ]; then
     filename='matrix-pre.json'

--- a/shells/ci.nix
+++ b/shells/ci.nix
@@ -1,14 +1,13 @@
 { pkgs, config, ... }:
 pkgs.mkShellNoCC {
-  packages =
-    [
-      config.pre-commit.settings.package
-      (pkgs.callPackage ../pkgs/dlang-nix-fetcher { })
-    ]
-    ++ (with pkgs; [
-      jq
-      nix-eval-jobs
-    ]);
+  packages = [
+    config.pre-commit.settings.package
+    (pkgs.callPackage ../pkgs/dlang-nix-fetcher { })
+  ]
+  ++ (with pkgs; [
+    jq
+    nix-eval-jobs
+  ]);
 
   shellHook = ''
     ${config.pre-commit.installationScript}

--- a/shells/ci.nix
+++ b/shells/ci.nix
@@ -1,7 +1,10 @@
 { pkgs, config, ... }:
 pkgs.mkShellNoCC {
   packages =
-    [ config.pre-commit.settings.package ]
+    [
+      config.pre-commit.settings.package
+      (pkgs.callPackage ../pkgs/dlang-nix-fetcher { })
+    ]
     ++ (with pkgs; [
       jq
       nix-eval-jobs

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -11,8 +11,7 @@ mkShell {
     dtools
 
     (writeShellScriptBin "repl" ''nix repl --file "$REPO_ROOT/repl.nix"'')
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isx86 [ dmd ];
+  ];
 
   shellHook = ''
     export REPO_ROOT="$PWD"

--- a/shells/default.nix
+++ b/shells/default.nix
@@ -11,7 +11,8 @@ mkShell {
     dtools
 
     (writeShellScriptBin "repl" ''nix repl --file "$REPO_ROOT/repl.nix"'')
-  ] ++ lib.optionals stdenv.hostPlatform.isx86 [ dmd ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isx86 [ dmd ];
 
   shellHook = ''
     export REPO_ROOT="$PWD"

--- a/src/dlang_nix/ci/cli.d
+++ b/src/dlang_nix/ci/cli.d
@@ -1,0 +1,233 @@
+module dlang_nix.ci.cli;
+
+// `dlang-nix-fetcher ci` — CI build-matrix helpers.
+//
+//   ci plan-matrix --weights <file>   (reads the package list as JSON on stdin)
+//       Packs the buildable, uncached packages into a GitHub Actions job matrix
+//       (`{"include":[{os,name,installables}]}`) by estimated build weight, so
+//       the matrix stays under GitHub's 256-configuration cap. Pure packing
+//       logic lives in `dlang_nix.ci.weights` (unit-tested).
+//
+//   ci calibrate [--remote-store <uri>] [--systems a,b] [--output <file>]
+//       Measures per-(system, family, tests-enabled) build times and writes the
+//       relative weights `plan-matrix` consumes.
+
+import std.algorithm : canFind, map, filter, startsWith, endsWith;
+import std.array : array, join, empty;
+import std.conv : to;
+import std.exception : enforce;
+import std.getopt : getopt, arraySep;
+import std.json : JSONValue, JSONType, parseJSON;
+import std.stdio : stdin, stdout, stderr, writeln;
+import std.string : strip;
+static import std.file;
+
+import dlang_nix.ci.weights;
+import dlang_nix.utils.commands : executeCommand, executeTimed;
+import dlang_nix.utils.json : toSortedPrettyJson;
+
+/// Entry point for the `ci` subcommand. `args` starts with the subcommand
+/// token (`["ci", "plan-matrix", ...]`), so `getopt` skips it like a program
+/// name.
+void runCi(string[] args) {
+    enforce(args.length >= 2,
+        "usage: dlang-nix-fetcher ci <plan-matrix|calibrate> [options]");
+    switch (args[1]) {
+        case "plan-matrix":
+            planMatrixCmd(args[1 .. $]);
+            break;
+        case "calibrate":
+            calibrateCmd(args[1 .. $]);
+            break;
+        default:
+            enforce(false, "unknown ci subcommand: " ~ args[1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// plan-matrix
+// ---------------------------------------------------------------------------
+
+private bool jsonBool(JSONValue v) =>
+    v.type == JSONType.true_;
+
+private string readAllStdin() {
+    import std.array : appender;
+
+    auto buf = appender!string;
+    foreach (chunk; stdin.byChunk(1 << 16))
+        buf.put(cast(const(char)[]) chunk);
+    return buf.data;
+}
+
+/// Parses `scripts/ci-build-weights.json` into the `Weights` lookup table. Each
+/// system maps a scalar `default` plus `family -> {build?, test?}` objects.
+Weights parseWeights(string text) {
+    Weights w;
+    foreach (string system, body; parseJSON(text).object) {
+        SystemWeights sw;
+        foreach (string key, val; body.object) {
+            if (key == "default")
+                sw.defaultWeight = val.integer;
+            else
+                foreach (string variant, v; val.object)
+                    sw.families[key][variant] = v.integer;
+        }
+        w[system] = sw;
+    }
+    return w;
+}
+
+private void planMatrixCmd(string[] args) {
+    string weightsPath;
+    args.getopt("weights", &weightsPath);
+    enforce(weightsPath.length, "--weights <file> is required");
+
+    const weights = parseWeights(std.file.readText(weightsPath));
+
+    // stdin: array of { attr, system, os, isCached, allowedToFail, doCheck }.
+    WeightedPkg[] buildable;
+    foreach (j; parseJSON(readAllStdin).array) {
+        auto o = j.object;
+        if (jsonBool(o["isCached"]) || jsonBool(o["allowedToFail"]))
+            continue;
+        const attr = o["attr"].str;
+        const system = o["system"].str;
+        const os = o["os"].str;
+        const doCheck = ("doCheck" in o) ? jsonBool(o["doCheck"]) : false;
+        buildable ~= WeightedPkg(
+            attr, system, os,
+            weightOf(weights, system, baseFamily(attr), doCheck));
+    }
+
+    JSONValue[] include;
+    foreach (b; planMatrix(buildable)) {
+        const installables = b.attrs
+            .map!(a => ".#packages." ~ b.system ~ "." ~ a)
+            .join(" ");
+        const name = b.attrs.length == 1
+            ? b.attrs[0] ~ " | " ~ b.system
+            : b.system ~ " · " ~ b.attrs.length.to!string ~ " pkgs";
+        include ~= JSONValue([
+            "os": JSONValue(b.os),
+            "name": JSONValue(name),
+            "installables": JSONValue(installables),
+        ]);
+    }
+    // Compact single line — the matrix is consumed via `fromJSON` and echoed
+    // into `$GITHUB_OUTPUT`.
+    writeln(JSONValue(["include": JSONValue(include)]).toString);
+}
+
+// ---------------------------------------------------------------------------
+// calibrate
+// ---------------------------------------------------------------------------
+
+private struct Rep {
+    string family;
+    string attr;
+    bool x86Only;
+}
+
+// One representative per (family, tests-enabled) class. `dub` appears twice
+// because its checked and build-only variants differ a lot in cost.
+private enum Rep[] reps = [
+    Rep("ldc", "ldc", false),
+    Rep("dmd", "dmd", true),
+    Rep("dub", "dub", false), // checked (the default alias)
+    Rep("dub", "dub-1_0_0", false), // build-only
+    Rep("ldc-binary", "ldc-binary-1_42_0", false),
+    Rep("dmd-binary", "dmd-binary-2_098_0", true),
+];
+
+private void calibrateCmd(string[] args) {
+    arraySep = ",";
+    string remoteStore;
+    string output = "scripts/ci-build-weights.json";
+    string[] systems;
+    args.getopt(
+        "remote-store", &remoteStore,
+        "output", &output,
+        "systems", &systems,
+    );
+    if (systems.empty)
+        systems = ["x86_64-linux", "x86_64-darwin", "aarch64-darwin"];
+
+    // Merge into any existing file so a partial run (e.g. one system) keeps the
+    // weights already measured for the others.
+    Weights weights;
+    if (std.file.exists(output))
+        weights = parseWeights(std.file.readText(output));
+
+    foreach (system; systems) {
+        const isX86 = system.startsWith("x86_64") || system.startsWith("i686");
+        // Linux builds locally; darwin builds on the (Rosetta-capable) remote.
+        const storeArg = system.endsWith("linux") || remoteStore.empty
+            ? "" : "--store " ~ remoteStore ~ " ";
+        foreach (rep; reps) {
+            if (rep.x86Only && !isX86)
+                continue;
+            const flake = ".#packages." ~ system ~ "." ~ rep.attr;
+
+            // Presence + doCheck probe (also skips packages absent on this
+            // platform, e.g. an old dub with no aarch64 host).
+            const probe = executeCommand(false,
+                "nix eval --json " ~ flake ~ ".doCheck 2>/dev/null");
+            if (probe is null) {
+                stderr.writefln("  skip %s (absent)", flake);
+                continue;
+            }
+            const doCheck = probe.strip == "true";
+
+            // Warm dependencies, then time a forced rebuild of just the target.
+            // `--rebuild` reports "may not be deterministic" (non-zero) for
+            // non-reproducible packages, but the build still ran and was timed,
+            // so that case counts as a valid measurement.
+            executeCommand(false,
+                "nix build " ~ storeArg ~ "-L --no-link " ~ flake);
+            const timed = executeTimed(
+                "nix build " ~ storeArg ~ "-L --no-link --rebuild " ~ flake);
+            const measured = timed.status == 0
+                || canFind(timed.output, "may not be deterministic");
+            if (!measured) {
+                stderr.writefln("  build FAILED %s — skipping", flake);
+                continue;
+            }
+            const secs = timed.elapsed.total!"seconds";
+            weights.require(system, SystemWeights.init)
+                .families.require(rep.family, null)[variantKey(doCheck)] =
+                secs < 1 ? 1 : secs;
+            stderr.writefln("  %s %s (doCheck=%s) -> %ss",
+                system, rep.family, doCheck, secs);
+        }
+        // `default` (unknown family) = cheapest measured class in the system.
+        long minW = long.max;
+        if (auto sys = system in weights)
+            foreach (_, variants; sys.families)
+                foreach (_v, v; variants)
+                    if (v < minW)
+                        minW = v;
+        if (minW != long.max)
+            weights.require(system, SystemWeights.init).defaultWeight = minW;
+    }
+
+    std.file.write(output, toSortedPrettyJson(weightsToJson(weights)) ~ "\n");
+    stderr.writefln("Wrote %s", output);
+}
+
+/// `Weights` -> JSONValue (scalar `default` + `family -> {variant: weight}`).
+private JSONValue weightsToJson(Weights w) {
+    JSONValue[string] outer;
+    foreach (system, sw; w) {
+        JSONValue[string] mid;
+        mid["default"] = JSONValue(sw.defaultWeight);
+        foreach (family, variants; sw.families) {
+            JSONValue[string] inner;
+            foreach (variant, v; variants)
+                inner[variant] = JSONValue(v);
+            mid[family] = JSONValue(inner);
+        }
+        outer[system] = JSONValue(mid);
+    }
+    return JSONValue(outer);
+}

--- a/src/dlang_nix/ci/weights.d
+++ b/src/dlang_nix/ci/weights.d
@@ -1,0 +1,192 @@
+module dlang_nix.ci.weights;
+
+// Build-time cost model + bin-packing for the CI build matrix.
+//
+// GitHub caps a job matrix at 256 entries, but the cold-cache build list is
+// larger (every uncached, buildable `(package, system)`), so we pack several
+// cheap packages into one job while letting heavy compiler builds keep their
+// own. Packing is driven by a *relative build-time weight* per package; the
+// weights themselves are measured by the `dlang-nix-fetcher ci calibrate`
+// subcommand (see `dlang_nix.ci.cli`) and committed to
+// `scripts/ci-build-weights.json`.
+
+import std.algorithm : filter, map, maxElement, sort, uniq;
+import std.array : array, empty;
+
+@safe:
+
+/// A package "family" is the attr name with its trailing `-<version>` removed.
+/// Versions are sanitised to digits/underscores, so the version always starts
+/// at the first `-` immediately followed by a digit. Names without such a
+/// marker (the unversioned aliases like `ldc-bootstrap`) are returned as-is.
+string baseFamily(string pkg) pure nothrow {
+    foreach (i; 0 .. pkg.length)
+        if (pkg[i] == '-' && i + 1 < pkg.length
+            && pkg[i + 1] >= '0' && pkg[i + 1] <= '9')
+            return pkg[0 .. i];
+    return pkg;
+}
+
+unittest {
+    assert(baseFamily("dmd-2_112_0") == "dmd");
+    assert(baseFamily("dmd-binary-2_098_0") == "dmd-binary");
+    assert(baseFamily("ldc-binary-1_42_0-beta2") == "ldc-binary");
+    assert(baseFamily("dub-1_43_0-alpha-5efed36") == "dub");
+    assert(baseFamily("ldc-bootstrap") == "ldc-bootstrap");
+    assert(baseFamily("dub") == "dub");
+}
+
+/// Per-system weights: a `default` fallback plus `family -> variant -> weight`,
+/// where the variant is `"build"` (doCheck=false) or `"test"` (doCheck=true).
+/// A family only lists the variant(s) it actually has.
+struct SystemWeights {
+    long defaultWeight = 1;
+    long[string][string] families;
+}
+
+/// `system -> SystemWeights`.
+alias Weights = SystemWeights[string];
+
+/// The variant key for a package's `doCheck`.
+string variantKey(bool doCheck) pure nothrow => doCheck ? "test" : "build";
+
+/// Looks up a package's weight: its family's matching variant, else whatever
+/// variant the family does have, else the system `default`, else `1` (so an
+/// unknown family is never zero-weighted, which would let unbounded numbers of
+/// them pack into a single job).
+long weightOf(const Weights w, string system, string family, bool doCheck) pure {
+    const sys = system in w;
+    if (sys is null)
+        return 1;
+    if (auto fam = family in sys.families) {
+        if (auto v = variantKey(doCheck) in *fam)
+            return *v;
+        foreach (_, v; *fam)
+            return v; // family has only the other variant — close enough
+    }
+    return sys.defaultWeight;
+}
+
+unittest {
+    Weights w;
+    SystemWeights sw;
+    sw.defaultWeight = 6;
+    sw.families["ldc"]["build"] = 87;
+    sw.families["dub"]["build"] = 6;
+    sw.families["dub"]["test"] = 139;
+    w["x86_64-linux"] = sw;
+
+    assert(weightOf(w, "x86_64-linux", "ldc", false) == 87);
+    assert(weightOf(w, "x86_64-linux", "dub", true) == 139);
+    assert(weightOf(w, "x86_64-linux", "dub", false) == 6);
+    assert(weightOf(w, "x86_64-linux", "dmd-binary", false) == 6); // default
+    assert(weightOf(w, "x86_64-linux", "ldc", true) == 87); // falls back to build
+    assert(weightOf(w, "aarch64-darwin", "ldc", true) == 1); // unknown system
+}
+
+/// A package tagged with its runner, system and estimated build weight.
+struct WeightedPkg {
+    string attr; // e.g. "ldc-1_42_0"
+    string system; // e.g. "x86_64-linux"
+    string os; // GH runner, e.g. "ubuntu-latest"
+    long weight;
+}
+
+/// One CI job: a set of packages built together on a runner.
+struct Bin {
+    string os;
+    string system;
+    string[] attrs;
+    long load;
+}
+
+/// First-Fit-Decreasing pack of one system's packages into bins of capacity
+/// `cap`. A package whose weight reaches `cap` fills its bin alone (nothing
+/// else fits) — which is exactly "a heavy build gets a dedicated job" once the
+/// caller sets `cap == maxWeight`.
+Bin[] packSystem(WeightedPkg[] pkgs, long cap) pure {
+    auto sorted = pkgs.dup;
+    sorted.sort!((a, b) => a.weight > b.weight);
+    Bin[] bins;
+    outer: foreach (p; sorted) {
+        foreach (ref b; bins)
+            if (b.load + p.weight <= cap) {
+                b.attrs ~= p.attr;
+                b.load += p.weight;
+                continue outer;
+            }
+        bins ~= Bin(p.os, p.system, [p.attr], p.weight);
+    }
+    return bins;
+}
+
+unittest {
+    WeightedPkg wp(string a, long w) => WeightedPkg(a, "x86_64-linux", "ubuntu-latest", w);
+
+    // Heaviest (== cap) stays solo; the two 50s share one bin.
+    auto bins = packSystem([wp("a", 100), wp("b", 50), wp("c", 50)], 100);
+    assert(bins.length == 2);
+    assert(bins[0].attrs == ["a"] && bins[0].load == 100);
+    assert(bins[1].load == 100); // b + c
+
+    // Many light packages pack densely under a generous cap.
+    auto light = packSystem([wp("a", 1), wp("b", 1), wp("c", 1), wp("d", 1), wp("e", 1)], 3);
+    assert(light.length == 2); // [3] + [2]
+    foreach (b; light)
+        assert(b.load <= 3);
+}
+
+/// Groups packages by system, packs each with capacity `= maxWeight` (so the
+/// makespan is ~one longest build and the heaviest builds are isolated), and
+/// guards the global job count: if it would exceed `capLimit`, capacities are
+/// scaled up uniformly and everything is repacked until it fits.
+Bin[] planMatrix(WeightedPkg[] pkgs, long capLimit = 240) pure {
+    auto systems = pkgs.map!(p => p.system).array.sort.uniq.array;
+    for (long scale = 1;; scale++) {
+        Bin[] bins;
+        foreach (sys; systems) {
+            auto sp = pkgs.filter!(p => p.system == sys).array;
+            if (sp.empty)
+                continue;
+            const maxW = sp.map!(p => p.weight).maxElement;
+            bins ~= packSystem(sp, maxW * scale);
+        }
+        if (bins.length <= capLimit || pkgs.length <= capLimit)
+            return bins;
+    }
+}
+
+unittest {
+    import std.algorithm : sort, sum, map;
+    import std.array : array, join;
+
+    WeightedPkg p(string a, string sys, long w) {
+        const os = sys == "x86_64-linux" ? "ubuntu-latest" : "macos-latest";
+        return WeightedPkg(a, sys, os, w);
+    }
+
+    auto pkgs = [
+        p("ldc-1", "x86_64-linux", 100),
+        p("dmd-1", "x86_64-linux", 80),
+        p("dub-1", "x86_64-linux", 9),
+        p("dub-2", "x86_64-linux", 9),
+        p("ldc-binary-1", "x86_64-linux", 1),
+        p("ldc-2", "aarch64-darwin", 100),
+        p("dub-3", "aarch64-darwin", 9),
+    ];
+    auto bins = planMatrix(pkgs);
+
+    // Every package appears exactly once (nothing lost or duplicated).
+    auto packed = bins.map!(b => b.attrs).join.array.sort.array;
+    auto input = pkgs.map!(p => p.attr).array.sort.array;
+    assert(packed == input);
+
+    // No bin exceeds its system's capacity (== that system's max weight here).
+    foreach (b; bins)
+        assert(b.load <= 100);
+
+    // The heavy compiler builds are isolated.
+    foreach (b; bins)
+        if (b.attrs.length == 1 && (b.attrs[0] == "ldc-1" || b.attrs[0] == "ldc-2"))
+            assert(b.load >= 100);
+}

--- a/src/dlang_nix/utils/commands.d
+++ b/src/dlang_nix/utils/commands.d
@@ -54,6 +54,24 @@ string executeCommand(bool dryRun, string command) {
     return result.status == 0 ? result.output : null;
 }
 
+import core.time : Duration;
+import std.datetime.stopwatch : StopWatch, AutoStart;
+
+alias TimedResult = Tuple!(int, "status", Duration, "elapsed", string, "output");
+
+/// Runs `command`, capturing its combined output, and returns the exit status,
+/// wall-clock time and output. Used by `calibrate` to measure per-package build
+/// times (the output lets it tell a real build failure from `nix build
+/// --rebuild`'s "may not be deterministic" mismatch, which still timed a real
+/// build).
+TimedResult executeTimed(string command) {
+    stderr.writefln(`> %s`, command);
+    auto sw = StopWatch(AutoStart.yes);
+    const result = executeShell(command, null, Config.none);
+    sw.stop();
+    return TimedResult(result.status, sw.peek, result.output);
+}
+
 // ---------------------------------------------------------------------------
 // Version predicates and selectors.
 //

--- a/src/main.d
+++ b/src/main.d
@@ -16,8 +16,16 @@ import std.typecons : tuple;
 import dlang_nix.utils.commands : prefech, Hash;
 import dlang_nix.utils.json : hashesToJsonValue, mergeHashesIntoJson, toSortedPrettyJson;
 import dlang_nix.components : Platform, Version, Component, supportedPlatforms, ComponentInfo;
+import dlang_nix.ci.cli : runCi;
 
 void main(string[] args) {
+    // `ci` subcommand: CI build-matrix helpers (see dlang_nix.ci.cli). Anything
+    // else falls through to the default release-prefetcher below.
+    if (args.length >= 2 && args[1] == "ci") {
+        runCi(args[1 .. $]);
+        return;
+    }
+
     Version[] componentVersions;
     Component component = Component.ldc;
     bool liveRun = false;


### PR DESCRIPTION
This PR fixes package build errors and test failures encountered after upgrading all Nix flake inputs.

### DMD Changes
- Replaced obsolete `gcc11` with standard `stdenv.cc` in compiler arguments.
- Skipped C++-interoperability tests on Linux (as they are already on macOS) since modern GCC has stdlib header inlining/linking behavior that breaks them.
- Used `rm -f` instead of `rm -v` in DMD checkPhase to prevent errors on older source versions where the skipped test files are absent.

### LDC Changes
- Created a `libxml2Shim` package providing `libxml2.so.2` compatibility for older pre-compiled binaries on Linux where libxml2 now ships `libxml2.so.16`.
- Lazily fetches and imports `llvmPackages_12` from a pinned `nixos-24.05` commit only when building older LDC versions (< 1.41.0) where it's required.
- Configured `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to allow older LDC versions to configure with newer CMake versions.

### DUB Changes
- Pinned DUB 1.0.0 bootstrap compiler to `ldc-binary-1_0_0` (restoring `std.stream` module availability).
- Conditionally apply the commandline.d missing-comma patch for DUB versions older than 1.1.0 to avoid breaking newer versions.
- Conditionally run `test/fetchzip.sh` substitution.
- Fallback to `build.sh` when `build.d` is missing, and pass `-L-no-pie` on Linux to disable PIE generation when linking against older non-PIC compiler libraries.
- Run `patchShebangs .` to correctly patch the interpreter path of `build.sh`.