### PR TITLE
feat(ci): weight-based build-matrix bin-packing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,8 @@ jobs:
       fail-fast: false
       matrix: ${{fromJSON(needs.generate-matrix.outputs.matrix)}}
 
-    name: ${{ matrix.package }} | ${{ matrix.system }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allowedToFail }}
 
     steps:
       - uses: actions/checkout@v7
@@ -65,8 +64,11 @@ jobs:
           name: ${{ vars.CACHIX_CACHE }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build ${{ matrix.package }}
-        run: nix build -L --json --no-link '.#packages.${{ matrix.attrPath }}'
+      # A job may build several packages (small ones are batched together by
+      # `dlang-nix-fetcher ci plan-matrix`). `--keep-going` so one failure still
+      # builds & caches the rest of the batch; the job still fails if any did.
+      - name: Build
+        run: nix build -L --no-link --keep-going ${{ matrix.installables }}
 
   results:
     runs-on: ubuntu-latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,321 @@
+# Architecture
+
+This repository is a Nix flake that packages the three D toolchains — **DMD**,
+**LDC**, and **dub** — across many versions and platforms, both from upstream
+**binary** releases and from **source**. It has two cooperating halves:
+
+1. **The Nix package layer** (`lib/`, `pkgs/`) — turns a catalog of pinned
+   release hashes into a large `packages.<system>.<attr>` attrset, and derives
+   the CI build matrix from it.
+2. **The D tool** (`src/`, built as `dlang-nix-fetcher`) — a helper that
+   (a) *prefetches* upstream releases to populate the hash catalogs, and
+   (b) *packs* the CI build matrix into a bounded set of GitHub Actions jobs.
+
+The seam between the halves is deliberately narrow and string-based:
+
+- The D fetcher **writes** the `pkgs/*/supported-{source,binary}-versions.json`
+  hash catalogs that the Nix layer **reads**.
+- The Nix layer **emits** a package list (via `nix-eval-jobs` + `lib`
+  helpers) that the D tool's `ci plan-matrix` **consumes** to produce the job
+  matrix.
+
+```
+            ┌─────────────────────────── D tool (dlang-nix-fetcher) ──────────────────────────┐
+ upstream   │  main.d runFetch!F                                   ci/cli.d plan-matrix        │
+ releases ──┼─►  fetch hashes ──► supported-*.json                 dedup + weight + bin-pack    │
+ (tags,     │        ▲                  │                                ▲           │          │
+  tarballs) │        └ sparkles:versions│ (read)                  (pkg list)│        │ (matrix) │
+            └───────────────────────────┼───────────────────────────────┬──┼────────┼──────────┘
+                                        ▼                               │  │        ▼
+                       ┌──────────── Nix layer ───────────────┐         │  │   .github/workflows
+                       │ pkgs/*/version-catalog.nix            │         │  │   build matrix jobs
+                       │ lib/version-catalog.nix genPkgVersions│──► self.packages.<sys>.<attr>
+                       │ pkgs/default.nix                      │         ▲  │
+                       │ lib/mk-gh-actions-matrix.nix          │─────────┘  │ (nix-eval-jobs)
+                       │ pkgs/*/build-status.nix               │            │
+                       └───────────────────────────────────────┘    scripts/ci-matrix.sh
+```
+
+---
+
+## 1. The Nix package layer
+
+### 1.1 Per-toolchain layout (`pkgs/<toolchain>/`)
+
+Each of `pkgs/dmd/`, `pkgs/ldc/`, `pkgs/dub/` contains:
+
+| File | Role |
+| --- | --- |
+| `supported-source-versions.json` | hash catalog for source builds |
+| `supported-binary-versions.json` | hash catalog for upstream binary releases (dub has none) |
+| `version-catalog.nix` | turns a `(version)` into a package *function* by reading the JSON |
+| `generic.nix` / `binary.nix` / `default.nix` | the actual build recipes (source / binary) |
+| `build-status.nix` | per-`(version, system)` build expectations |
+
+### 1.2 The hash catalogs — `supported-{source,binary}-versions.json`
+
+These are the source of truth for *which versions exist* and *how to fetch
+them*. They are **machine-written** by the D fetcher (§3) and shaped
+`{ version -> { component -> SRI-hash | null } }`:
+
+- **Binary** (`dmd`/`ldc`): keys are download *platform* tokens, values are SRI
+  hashes; `null` means "not published for that platform".
+  ```jsonc
+  // pkgs/ldc/supported-binary-versions.json
+  "1.0.0": { "linux-x86_64": "sha256-…", "osx-arm64": null, … }
+  ```
+- **Source**:
+  - `dmd`: one hash per upstream repo component (`dmd`, `phobos`, `tools`, and
+    `druntime` only before 2.101 when it was a separate repo), plus a
+    hand-maintained `host-d-compiler` naming the bootstrap host attr.
+    ```jsonc
+    "2.087.1": { "dmd": "sha256-…", "druntime": "sha256-…", "phobos": "sha256-…",
+                 "tools": "sha256-…", "host-d-compiler": "ldc-binary-1_21_0" }
+    ```
+  - `ldc`: a single `src` tarball hash.
+  - `dub`: the `dub` source hash plus an auto-pinned `rev` (the tag's commit),
+    and an optional `d-compiler` host pin.
+    ```jsonc
+    "1.0.0": { "dub": "sha256-…", "rev": "b59af2b8…" }
+    ```
+
+The per-component **SRI hashes** and dub's **`rev`** are produced by the
+fetcher; the **bootstrap cross-references** (`host-d-compiler`, `d-compiler`)
+are maintained by hand.
+
+### 1.3 `version-catalog.nix` — JSON → package function
+
+`pkgs/<toolchain>/version-catalog.nix` exposes three values consumed by the
+shared generator:
+
+- `supportedVersions` — the parsed JSON (`{ source, binary }`).
+- `getSourceVersion ourPkgs version` / `getBinaryVersion pkgs version` — look up
+  the version's hashes and `import` the matching build recipe (`generic.nix` /
+  `binary.nix` / `default.nix`), wiring bootstrap hosts (`host-d-compiler`,
+  `d-compiler`) by name from `ourPkgs`. `getBinaryVersion = null` signals "no
+  binary catalog" (dub).
+
+### 1.4 `lib/version-catalog.nix` — `genPkgVersions`
+
+The shared generator that turns a toolchain's catalog into attrs. For a
+`pkgName`:
+
+- **`flattened "binary" | "source"`** → `{ "<pname><suffix>-<sanitized-ver>" =
+  drv }`, where the **source build takes no suffix** and the **binary build is
+  suffixed `-binary`**, and `sanitizeVersion` replaces `.` with `_`
+  (`2.112.0` → `2_112_0`). So `dmd-2_112_0` is source, `dmd-binary-2_098_0` is
+  binary.
+- **`hierarchical`** → `{ "<pname>" = { source = {ver→drv}; binary = {ver→drv} } }`
+  (exposed as `legacyPackages`).
+- `callWithExtras` injects only the extra args a recipe declares (`dCompiler`,
+  `hostDCompiler`, `Foundation`); `filterBySystem` drops versions whose
+  `meta.platforms` excludes the current system.
+
+### 1.5 `pkgs/default.nix` — the package set
+
+A `flake-parts` `perSystem` module that assembles `packages` from
+`genPkgVersions … flattened …` plus a few **bare aliases** that pin a default
+version (`ldc`, `dub`, `dmd`, and the bootstrap pointers `ldc-bootstrap`,
+`dmd-bootstrap`). DMD is gated behind `pkgs.hostPlatform.isx86`. These aliases
+are flake-attr pointers to a concrete versioned derivation — the D tool's
+matrix dedup (§3.4) collapses them so each derivation builds once.
+
+### 1.6 `build-status.nix` — expected build/check outcomes
+
+`pkgs/<toolchain>/build-status.nix` is a `{ version -> { system -> { build,
+check, skippedTests } } }` map encoding, per `(version, system)`:
+
+- `build` — whether the package is *expected* to build (a `false` here makes CI
+  treat a failure as non-fatal; see `allowedToFail` in §2.2).
+- `check` — whether to run the upstream test suite (`doCheck`).
+- `skippedTests` — individual upstream tests to disable (flaky/sandbox-hostile).
+
+Each toolchain encodes this differently: `dmd` and `dub` compute it from
+version *ranges* (`between start end`) with large curated `skippedTests` lists
+and per-OS carve-outs; `ldc` is a sparse literal table of exceptions. Packages
+expose the looked-up record via `passthru.buildStatus`, and the
+default (when a version/system is absent) is `{ build = true; check = true;
+skippedTests = []; }` (`lib/build-status.nix:getBuildStatus`).
+
+---
+
+## 2. `lib/` — flake library
+
+`lib/default.nix` wires everything under `flake.lib`:
+
+| Module | Provides |
+| --- | --- |
+| `version-utils.nix` | SemVer-ish helpers over `builtins.compareVersions` (`versionBetween[Inclusive]`, `sortVersions`, `latestVersion`) |
+| `build-status.nix` | `getBuildStatus package version system` → the `build-status.nix` record (with the build-everything default) |
+| `dc.nix` | DMD-frontend wrapper info for a compiler derivation (`dcToDmdMapping`, `normalizedName`, `ldcToDmdVersion`, `getDCInfo`) |
+| `mk-gh-actions-matrix.nix` | the CI matrix inputs (below) |
+| `version-catalog.nix` | `genPkgVersions` (§1.4) |
+
+### 2.1 `nixSystemToGHPlatform`
+
+The closed set of CI systems and their GitHub runners:
+`x86_64-linux → ubuntu-latest`, `x86_64-darwin → macos-26-intel`,
+`aarch64-darwin → macos-latest`. (Other systems appear in `build-status.nix`
+but only these three are built in CI.)
+
+### 2.2 `mkGHActionsMatrix.include` and the maps
+
+`mkGHActionsMatrix.include` is the cartesian product of the three CI systems and
+every attr in `self.packages.<system>`, each entry carrying:
+
+- `os` (runner), `system`, `package` (attr name), `attrPath`,
+- `allowedToFail = !buildStatus.build` (packages not expected to build may fail
+  without failing CI),
+- `doCheck = p.doCheck or false`.
+
+Two regroupings feed the D tool, both shaped `{ package -> { system -> flag } }`:
+
+- **`doCheckMap`** — drives per-package weight selection (a test-running build is
+  much heavier than a build-only one).
+- **`allowedToFailMap`** — lets `plan-matrix` drop packages that needn't build.
+
+---
+
+## 3. The D tool — `src/` (`dlang-nix-fetcher`)
+
+A single executable (`src/main.d`) with two roles. It depends on the
+`sparkles:versions` dub package (see `dub.sdl`) for typed version
+parsing/ordering. Module layout:
+
+```
+src/main.d                    entry point + the release-prefetcher (runFetch!F)
+src/dlang_nix/
+  components.d                the PackageFamily concept, the families, PackageRelease
+  utils/conv.d                parseEnum (value-matching enum parser)
+  utils/commands.d            shell-out helpers, git tag fetch, typed version resolvers
+  utils/json.d                hash-table ⇄ sorted-pretty JSON
+  ci/weights.d                cost model + First-Fit-Decreasing bin-packer
+  ci/cli.d                    `ci plan-matrix` / `ci calibrate`
+```
+
+### 3.1 The `PackageFamily` concept (`components.d`)
+
+The toolchain "families" are modelled as a compile-time concept, in the spirit
+of `sparkles:versions` (a plain struct + a `static assert`, no base class, no
+registration):
+
+```d
+enum isPackageFamily(C) = is(typeof(checkPackageFamily!C)); // name, VersionType, url, platforms, …
+```
+
+Five family structs each carry a `name` (the attr/pname prefix — the seam with
+the Nix layer §1.4), a typed `VersionType`, the static fetch surface
+(`url`, `platforms`, `supportedVersionsFile`, `tagsRepo`, `defaultVersions`,
+`unpackingNeed`), and optional capabilities:
+
+| Struct | `name` | `VersionType` | notes |
+| --- | --- | --- | --- |
+| `DmdBinary` | `dmd-binary` | `Dmd` | downloads.dlang.org tarball |
+| `Dmd` | `dmd` | `Dmd` | github source, unpack |
+| `LdcBinary` | `ldc-binary` | `SemVer` | github release tarball |
+| `Ldc` | `ldc` | `SemVer` | github `-src.tar.gz` |
+| `Dub` | `dub` | `SemVer` | github source; `pinsRev` capability |
+
+`alias Families = AliasSeq!(…)` is the **single registry** — the `--component`
+CLI tokens, dispatch, and allowed-value help are all inferred from `F.name`.
+The `Dmd` *version scheme* (zero-padded 3-digit minor, e.g. `2.098.0`) and
+`SemVer` differ, which is why the scheme is per-family.
+
+`PackageRelease!C` adds a concrete version to a family: it stores the verbatim
+underscore version (`rawVersion`) for an exact attr round-trip plus a
+best-effort typed `ver` for ordering. `baseFamily(attr)` strips the trailing
+`-<version>` to recover the family name.
+
+### 3.2 The prefetcher (`main.d` `runFetch!F`)
+
+`dlang-nix-fetcher --component <name> [--versions … | --first-version … --last-version …]`
+resolves the requested versions, fetches each `(version, platform)` with
+`nix-prefetch-url`, and merges the resulting SRI hashes into the family's
+`supportedVersionsFile`. The pipeline is **typed end-to-end** on
+`F.VersionType`; `string` appears only at the CLI boundary (`parseLoose`) and
+the JSON boundary (`toString` keys). For `--first/--last`,
+`resolveVersionRange!V` (`utils/commands.d`) walks `git ls-remote` tags and
+keeps the latest patch per minor; families with the `pinsRev` capability (dub)
+also resolve each tag's commit via `resolveTagRevs!V`. `utils/json.d`
+(`mergeHashesIntoJson`) renders the merged table back to version-sorted JSON.
+
+### 3.3 The cost model + packer (`ci/weights.d`)
+
+GitHub caps a job matrix at 256 entries, but the cold-cache build list (every
+uncached buildable `(package, system)`) is larger. `weights.d` defines:
+
+- `NixSystem`, `Variant` (`build`/`test`), and `Weights = SystemWeights[NixSystem]`
+  — a `family -> variant -> weight` table loaded from
+  `scripts/ci-build-weights.json` (measured by `ci calibrate`).
+- `weightOf(weights, system, family, variant)` — the per-package cost.
+- `packSystem` — **First-Fit-Decreasing** packing into bins of capacity
+  `cap`; a package whose weight reaches `cap` fills its bin alone (a heavy
+  compiler build gets a dedicated job).
+- `planMatrix` — packs each system with `cap = maxWeight`, scaling capacities up
+  uniformly and repacking if the job count would exceed the limit.
+
+The packer is deliberately **identity-agnostic**: it operates on a flat
+`WeightedItem { name, attrPath, system, os, weight }`, never on the rich types.
+
+### 3.4 `ci plan-matrix` / `ci calibrate` (`ci/cli.d`)
+
+`plan-matrix` reads the package list as JSON on stdin and:
+
+1. **filters** out cached / allowed-to-fail records;
+2. **dedups** by derivation identity `(system, outPath)`, preferring the attr
+   that parses to a concrete `PackageRelease` — so the `dmd` alias collapses
+   into `dmd-2_112_0` and the derivation is built once;
+3. **dispatches** each surviving attr through `Families` (matching
+   `baseFamily(attr) == F.name`) into a typed `PackageBuildTarget!F`, whose
+   `flakeAttrPath` is the *retargetable* `packages.<system>.<attr>` (no `.#`);
+4. **projects** to `WeightedItem` and runs `planMatrix`;
+5. **emits** `{ include: [ { os, name, installables } ] }`, prepending `.#` to
+   each `attrPath`. Several small packages share one job's `installables`.
+
+`calibrate` measures the per-`(system, family, variant)` build times (timing a
+forced rebuild of representative packages) and writes
+`scripts/ci-build-weights.json`.
+
+---
+
+## 4. `scripts/ci-matrix.sh` and the CI flow
+
+`ci-matrix.sh` is the glue invoked by `.github/generate-matrix`:
+
+1. **`eval_packages_to_json`** — runs `nix-eval-jobs` over `packages` for all
+   systems and joins it with `lib.allowedToFailMap`, `lib.doCheckMap`, and
+   `lib.nixSystemToGHPlatform`, producing one record per `(package, system)`
+   with `{ package, system, os, isCached, allowedToFail, doCheck, outPath,
+   cache_url, … }`. The `outPath` (the derivation's `outputs.out`) is the
+   dedup key.
+2. **`save_gh_ci_matrix`** — projects those records to
+   `{ attr, system, os, isCached, allowedToFail, doCheck, outPath }` and pipes
+   them through `dlang-nix-fetcher ci plan-matrix --weights
+   scripts/ci-build-weights.json`, writing the resulting matrix to
+   `$GITHUB_OUTPUT`.
+3. **`convert_nix_eval_to_table_summary_json`** — renders the per-package cache
+   status table posted as a PR comment.
+
+In `.github/workflows/ci.yml`, the `generate-matrix` job's output becomes the
+`build` job's `strategy.matrix`; each build job runs
+`nix build -L --no-link --keep-going ${{ matrix.installables }}` (so one failure
+in a batched job still builds/caches the rest), and a final `results` job fails
+CI if any required build failed.
+
+---
+
+## 5. Cross-cutting conventions
+
+- **The `name`/attr/weight-key correspondence.** A family's `F.name`
+  (`dmd-binary`), the Nix attr prefix from `genPkgVersions … flattened`
+  (`dmd-binary-2_098_0`), and the weight-table key in
+  `ci-build-weights.json` are the *same string*. `baseFamily` recovers it from
+  any attr.
+- **Source vs binary naming.** Source builds are unsuffixed
+  (`dmd`, `ldc`, `dub`); the binary variant is `-binary`.
+- **Two version schemes.** DMD uses zero-padded 3-digit minors (`2.098.0`);
+  LDC/dub use canonical SemVer. The scheme lives on the family
+  (`F.VersionType`), so versions parse/sort correctly on both sides of the seam.
+- **Version string sanitisation.** Dots become underscores in attr names
+  (`2.112.0` ↔ `2_112_0`); `PackageRelease` round-trips this exactly, and Nix's
+  `sanitizeVersion` does the forward direction.

--- a/dub.sdl
+++ b/dub.sdl
@@ -15,3 +15,10 @@ configuration "update" {
     mainSourceFile "scripts/update.d"
     excludedSourceFiles "src/main.d"
 }
+
+configuration "unittest" {
+    targetType "library"
+    dependency "silly" version="~>1.1.1"
+
+    dflags "-checkaction=context" "-allinst"
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,6 +5,7 @@
     dc = import ./dc.nix { inherit lib; };
     inherit (import ./mk-gh-actions-matrix.nix { inherit self lib; })
       allowedToFailMap
+      doCheckMap
       nixSystemToGHPlatform
       ;
     versionUtils = import ./version-utils.nix { };

--- a/lib/mk-gh-actions-matrix.nix
+++ b/lib/mk-gh-actions-matrix.nix
@@ -17,6 +17,16 @@ rec {
     ))
   ];
 
+  # `{ package -> { system -> doCheck } }`, consumed by `dlang-nix-fetcher ci
+  # plan-matrix` to weight each package (test-running builds are heavier than
+  # build-only ones).
+  doCheckMap = lib.pipe (mkGHActionsMatrix.include) [
+    (builtins.groupBy (p: p.package))
+    (builtins.mapAttrs (
+      n: v: builtins.mapAttrs (s: ps: (builtins.head ps).doCheck) (builtins.groupBy (p: p.system) v)
+    ))
+  ];
+
   mkGHActionsMatrix = {
     include = lib.pipe (builtins.attrNames nixSystemToGHPlatform) [
       (builtins.concatMap (
@@ -33,6 +43,7 @@ rec {
             os = platform;
             allowedToFail =
               !(p.passthru.buildStatus or (throw "${package} does not expose build status")).build;
+            doCheck = p.doCheck or false;
             inherit system package;
             attrPath = "packages.${system}.${lib.strings.escapeNixIdentifier package}";
           }

--- a/pkgs/dlang-nix-fetcher/default.nix
+++ b/pkgs/dlang-nix-fetcher/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildDubPackage,
+}:
+# The repo's `dlang-nix-fetcher` D tool: prefetches DMD/LDC/dub releases and,
+# via the `ci` subcommand, packs the CI build matrix. Packaged so the
+# matrix-generation step (`scripts/ci-matrix.sh`) can call `dlang-nix-fetcher ci
+# plan-matrix` from the `.#ci` dev shell without a `dub build` on the hot path.
+# Built with the nixpkgs LDC (not the repo's own, to avoid a build cycle).
+buildDubPackage {
+  pname = "dlang-nix-fetcher";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../..;
+    fileset = lib.fileset.unions [
+      ../../dub.sdl
+      ../../dub.selections.json
+      ../../src
+    ];
+  };
+
+  dubLock = ./dub-lock.json;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/dlang-nix-fetcher "$out/bin/dlang-nix-fetcher"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fetches DMD/LDC/dub releases and packs the dlang.nix CI build matrix";
+    mainProgram = "dlang-nix-fetcher";
+  };
+}

--- a/pkgs/dlang-nix-fetcher/dub-lock.json
+++ b/pkgs/dlang-nix-fetcher/dub-lock.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "expected": {
+      "version": "0.4.1",
+      "sha256": "1ahr7gbjl6dgw1qs9x5yzcwhbzfg7ygdlsm9gw4hgmm1xrfcpri0"
+    },
+    "semver": {
+      "version": "0.5.0",
+      "sha256": "06w7yg5r6xpy8ypykwhzjif5z2fj3jrjzqkzyvrbpih4pgxg5hmg"
+    },
+    "silly": {
+      "version": "1.1.1",
+      "sha256": "0fz7ib715sfk3w69i6xns5pwd4caahvfqjf32v13daxm1ms8xdzz"
+    },
+    "sparkles": {
+      "version": "0.4.0",
+      "sha256": "10dvrqrfw3ckvvdzazy32ys2f3wyv2ri4y414z44rnfdv9nlx93w"
+    }
+  }
+}

--- a/scripts/ci-build-weights.json
+++ b/scripts/ci-build-weights.json
@@ -1,0 +1,51 @@
+{
+  "aarch64-darwin": {
+    "default": 8,
+    "dub": {
+      "test": 104
+    },
+    "ldc": {
+      "build": 89
+    },
+    "ldc-binary": {
+      "build": 8
+    }
+  },
+  "x86_64-darwin": {
+    "default": 8,
+    "dmd": {
+      "build": 87
+    },
+    "dmd-binary": {
+      "build": 12
+    },
+    "dub": {
+      "test": 210
+    },
+    "ldc": {
+      "build": 152
+    },
+    "ldc-binary": {
+      "build": 8
+    }
+  },
+  "x86_64-linux": {
+    "default": 6,
+    "dmd": {
+      "test": 245
+    },
+    "dmd-binary": {
+      "build": 12
+    },
+    "dub": {
+      "build": 6,
+      "test": 139
+    },
+    "ldc": {
+      "build": 87
+    },
+    "ldc-binary": {
+      "build": 7
+    }
+  }
+}

--- a/scripts/ci-matrix.sh
+++ b/scripts/ci-matrix.sh
@@ -14,21 +14,26 @@ eval_packages_to_json() {
   cachix_url="https://${CACHIX_CACHE}.cachix.org"
 
   nix eval --json .#lib.allowedToFailMap >"${result_dir}/allowed-to-fail.json"
+  nix eval --json .#lib.doCheckMap >"${result_dir}/do-check.json"
   nix eval --json .#lib.nixSystemToGHPlatform >"${result_dir}/system-to-gh-platform.json"
 
   nix_eval_for_all_systems "$flake_attr_pre" "$flake_attr_post" |
-    cat "${result_dir}/allowed-to-fail.json" "${result_dir}/system-to-gh-platform.json" - |
+    cat "${result_dir}/allowed-to-fail.json" "${result_dir}/do-check.json" \
+      "${result_dir}/system-to-gh-platform.json" - |
     jq -sr '
     .[0] as $allowed_to_fail
-    | .[1] as $system_to_gh_platform
-    | .[2:] as $nix_eval_results
+    | .[1] as $do_check
+    | .[2] as $system_to_gh_platform
+    | .[3:] as $nix_eval_results
     | $nix_eval_results
     | map({
       package: .attr,
       attrPath: "\(.system).\(.attr)",
       allowedToFail: $allowed_to_fail[.attr][.system],
+      doCheck: ($do_check[.attr][.system] // false),
       isCached,
       system,
+      outPath: .outputs.out,
       cache_url: .outputs.out
         | "'"$cachix_url"'/\(match("^\/nix\/store\/([^-]+)-").captures[0].string).narinfo",
       os: $system_to_gh_platform[.system]
@@ -38,8 +43,12 @@ eval_packages_to_json() {
 }
 
 save_gh_ci_matrix() {
-  packages_to_build=$(echo "$packages" | jq -c '. | map(select((.isCached | not) and (.allowedToFail | not)))')
-  matrix='{"include":'"$packages_to_build"'}'
+  # Pack the buildable, uncached packages into a job matrix by estimated build
+  # weight (keeps us under GitHub's 256-configuration cap). Packing + filtering
+  # live in the `dlang-nix-fetcher ci` D tool; see src/dlang_nix/ci/.
+  matrix=$(echo "$packages" |
+    jq -c '[ .[] | { attr: .package, system, os, isCached, allowedToFail, doCheck, outPath } ]' |
+    dlang-nix-fetcher ci plan-matrix --weights "$root_dir/scripts/ci-build-weights.json")
   filename=''
   if [ "${IS_INITIAL:-true}" = "true" ]; then
     filename='matrix-pre.json'

--- a/shells/ci.nix
+++ b/shells/ci.nix
@@ -1,7 +1,10 @@
 { pkgs, config, ... }:
 pkgs.mkShellNoCC {
   packages =
-    [ config.pre-commit.settings.package ]
+    [
+      config.pre-commit.settings.package
+      (pkgs.callPackage ../pkgs/dlang-nix-fetcher { })
+    ]
     ++ (with pkgs; [
       jq
       nix-eval-jobs

--- a/src/dlang_nix/ci/cli.d
+++ b/src/dlang_nix/ci/cli.d
@@ -1,0 +1,313 @@
+module dlang_nix.ci.cli;
+
+// `dlang-nix-fetcher ci` — CI build-matrix helpers.
+//
+//   ci plan-matrix --weights <file>   (reads the package list as JSON on stdin)
+//       Packs the buildable, uncached packages into a GitHub Actions job matrix
+//       (`{"include":[{os,name,installables}]}`) by estimated build weight, so
+//       the matrix stays under GitHub's 256-configuration cap. Pure packing
+//       logic lives in `dlang_nix.ci.weights` (unit-tested).
+//
+//   ci calibrate [--remote-store <uri>] [--systems a,b] [--output <file>]
+//       Measures per-(system, family, tests-enabled) build times and writes the
+//       relative weights `plan-matrix` consumes.
+
+import std.algorithm : canFind, map, filter, startsWith, endsWith;
+import std.array : array, join, empty;
+import std.conv : to;
+import std.exception : enforce;
+import std.getopt : getopt, arraySep;
+import std.json : JSONValue, JSONType, parseJSON;
+import std.stdio : stdin, stdout, stderr, writeln;
+import std.string : strip;
+static import std.file;
+
+import dlang_nix.ci.weights;
+import dlang_nix.components : Families, baseFamily, PackageRelease, isPackageFamily;
+import dlang_nix.utils.commands : executeCommand, executeTimed;
+import dlang_nix.utils.conv : parseEnum;
+import dlang_nix.utils.json : toSortedPrettyJson;
+
+/// Entry point for the `ci` subcommand. `args` starts with the subcommand
+/// token (`["ci", "plan-matrix", ...]`), so `getopt` skips it like a program
+/// name.
+void runCi(string[] args) {
+    enforce(args.length >= 2,
+        "usage: dlang-nix-fetcher ci <plan-matrix|calibrate> [options]");
+    switch (args[1]) {
+        case "plan-matrix":
+            planMatrixCmd(args[1 .. $]);
+            break;
+        case "calibrate":
+            calibrateCmd(args[1 .. $]);
+            break;
+        default:
+            enforce(false, "unknown ci subcommand: " ~ args[1]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// plan-matrix
+// ---------------------------------------------------------------------------
+
+private bool jsonBool(JSONValue v) =>
+    v.type == JSONType.true_;
+
+private string readAllStdin() {
+    import std.array : appender;
+
+    auto buf = appender!string;
+    foreach (chunk; stdin.byChunk(1 << 16))
+        buf.put(cast(const(char)[]) chunk);
+    return buf.data;
+}
+
+/// Parses `scripts/ci-build-weights.json` into the `Weights` lookup table. Each
+/// system maps a scalar `default` plus `family -> {build?, test?}` objects.
+Weights parseWeights(string text) {
+    Weights w;
+    foreach (string system, body; parseJSON(text).object) {
+        SystemWeights sw;
+        foreach (string key, val; body.object) {
+            if (key == "default")
+                sw.defaultWeight = val.integer;
+            else
+                foreach (string variant, v; val.object)
+                    sw.families[key][variant.to!Variant] = v.integer;
+        }
+        w[system.parseEnum!NixSystem] = sw;
+    }
+    return w;
+}
+
+/// A buildable matrix record as read from stdin JSON.
+private struct Record {
+    string attr;
+    NixSystem system;
+    string os;
+    bool doCheck;
+    string outPath; // derivation output path; dedups flake-attr aliases
+}
+
+/// A `PackageRelease` plus its build axes (`system`, `variant`). Projects to a
+/// `WeightedItem` for the (identity-agnostic) packer.
+struct PackageBuildTarget(C) if (isPackageFamily!C) {
+    PackageRelease!C release;
+    NixSystem system;
+    Variant variant;
+
+    long weight(in Weights w) const => weightOf(w, system, C.name, variant);
+    // Retargetable attr path (no `.#`): callers prepend a flake ref.
+    string flakeAttrPath() const => "packages." ~ cast(string) system ~ "." ~ release.toString;
+}
+
+/// Whether `attr` names a concrete versioned release of a known family, as
+/// opposed to a bare flake-attr alias (`dmd`, `ldc-bootstrap`).
+private bool isConcreteRelease(string attr) {
+    const fam = baseFamily(attr);
+    if (attr.length <= fam.length)
+        return false; // no `-<version>` suffix
+    bool known = false;
+    static foreach (F; Families)
+        if (fam == F.name)
+            known = true;
+    return known;
+}
+
+/// Collapses flake-attr aliases: records building the same derivation
+/// (`(system, outPath)`) are deduplicated, preferring the concrete versioned
+/// release over a bare alias — so `dmd-2_112_0` builds once and `dmd` is dropped.
+/// Input order is preserved for the surviving representatives.
+private Record[] dedup(Record[] records) {
+    Record[string] best;
+    string[] order;
+    foreach (rec; records) {
+        // No outPath (eval gap) ⇒ never collapse: key on the attr instead.
+        const key = (cast(string) rec.system) ~ "\0"
+            ~ (rec.outPath.length ? rec.outPath : "\x01" ~ rec.attr);
+        if (auto existing = key in best) {
+            if (isConcreteRelease(rec.attr) && !isConcreteRelease(existing.attr))
+                *existing = rec;
+        } else {
+            best[key] = rec;
+            order ~= key;
+        }
+    }
+    return order.map!(k => best[k]).array;
+}
+
+/// Dispatches a record to its family and projects it to a `WeightedItem`.
+private WeightedItem toItem(const Weights weights, Record rec) {
+    const fam = baseFamily(rec.attr);
+    const variant = cast(Variant) rec.doCheck;
+    static foreach (F; Families) {{
+        if (fam == F.name) {
+            auto t = PackageBuildTarget!F(
+                PackageRelease!F.parse(rec.attr), rec.system, variant);
+            return WeightedItem(
+                t.release.toString, t.flakeAttrPath, rec.system, rec.os, t.weight(weights));
+        }
+    }}
+    // Orphan alias (no matching family): keep verbatim, default weight.
+    return WeightedItem(
+        rec.attr, "packages." ~ (cast(string) rec.system) ~ "." ~ rec.attr,
+        rec.system, rec.os, weightOf(weights, rec.system, fam, variant));
+}
+
+private void planMatrixCmd(string[] args) {
+    string weightsPath;
+    args.getopt("weights", &weightsPath);
+    enforce(weightsPath.length, "--weights <file> is required");
+
+    const weights = parseWeights(std.file.readText(weightsPath));
+
+    // stdin: array of { attr, system, os, isCached, allowedToFail, doCheck, outPath }.
+    Record[] records;
+    foreach (j; parseJSON(readAllStdin).array) {
+        auto o = j.object;
+        if (jsonBool(o["isCached"]) || jsonBool(o["allowedToFail"]))
+            continue;
+        Record rec;
+        rec.attr = o["attr"].str;
+        rec.system = o["system"].str.parseEnum!NixSystem;
+        rec.os = o["os"].str;
+        rec.doCheck = ("doCheck" in o) ? jsonBool(o["doCheck"]) : false;
+        rec.outPath = ("outPath" in o) ? o["outPath"].str : "";
+        records ~= rec;
+    }
+
+    auto items = dedup(records).map!(rec => toItem(weights, rec)).array;
+
+    JSONValue[] include;
+    foreach (b; planMatrix(items)) {
+        // Prepend the current-flake ref `.#`; `attrPath` itself is retargetable.
+        const installables = b.items.map!(i => ".#" ~ i.attrPath).join(" ");
+        const string sys = b.system;
+        const name = b.items.length == 1
+            ? b.items[0].name ~ " | " ~ sys
+            : sys ~ " · " ~ b.items.length.to!string ~ " pkgs";
+        include ~= JSONValue([
+            "os": JSONValue(b.os),
+            "name": JSONValue(name),
+            "installables": JSONValue(installables),
+        ]);
+    }
+    // Compact single line — the matrix is consumed via `fromJSON` and echoed
+    // into `$GITHUB_OUTPUT`.
+    writeln(JSONValue(["include": JSONValue(include)]).toString);
+}
+
+// ---------------------------------------------------------------------------
+// calibrate
+// ---------------------------------------------------------------------------
+
+private struct Rep {
+    string family;
+    string attr;
+    bool x86Only;
+}
+
+// One representative per (family, tests-enabled) class. `dub` appears twice
+// because its checked and build-only variants differ a lot in cost.
+private enum Rep[] reps = [
+    Rep("ldc", "ldc", false),
+    Rep("dmd", "dmd", true),
+    Rep("dub", "dub", false), // checked (the default alias)
+    Rep("dub", "dub-1_0_0", false), // build-only
+    Rep("ldc-binary", "ldc-binary-1_42_0", false),
+    Rep("dmd-binary", "dmd-binary-2_098_0", true),
+];
+
+private void calibrateCmd(string[] args) {
+    arraySep = ",";
+    string remoteStore;
+    string output = "scripts/ci-build-weights.json";
+    string[] systemArgs;
+    args.getopt(
+        "remote-store", &remoteStore,
+        "output", &output,
+        "systems", &systemArgs,
+    );
+    auto systems = systemArgs.empty
+        ? [NixSystem.x86_64_linux, NixSystem.x86_64_darwin, NixSystem.aarch64_darwin]
+        : systemArgs.map!(parseEnum!NixSystem).array;
+
+    // Merge into any existing file so a partial run (e.g. one system) keeps the
+    // weights already measured for the others.
+    Weights weights;
+    if (std.file.exists(output))
+        weights = parseWeights(std.file.readText(output));
+
+    foreach (system; systems) {
+        const string sysStr = system;
+        const isX86 = sysStr.startsWith("x86_64") || sysStr.startsWith("i686");
+        // Linux builds locally; darwin builds on the (Rosetta-capable) remote.
+        const storeArg = sysStr.endsWith("linux") || remoteStore.empty
+            ? "" : "--store " ~ remoteStore ~ " ";
+        foreach (rep; reps) {
+            if (rep.x86Only && !isX86)
+                continue;
+            const flake = ".#packages." ~ sysStr ~ "." ~ rep.attr;
+
+            // Presence + doCheck probe (also skips packages absent on this
+            // platform, e.g. an old dub with no aarch64 host).
+            const probe = executeCommand(false,
+                "nix eval --json " ~ flake ~ ".doCheck 2>/dev/null");
+            if (probe is null) {
+                stderr.writefln("  skip %s (absent)", flake);
+                continue;
+            }
+            const doCheck = probe.strip == "true";
+
+            // Warm dependencies, then time a forced rebuild of just the target.
+            // `--rebuild` reports "may not be deterministic" (non-zero) for
+            // non-reproducible packages, but the build still ran and was timed,
+            // so that case counts as a valid measurement.
+            executeCommand(false,
+                "nix build " ~ storeArg ~ "-L --no-link " ~ flake);
+            const timed = executeTimed(
+                "nix build " ~ storeArg ~ "-L --no-link --rebuild " ~ flake);
+            const measured = timed.status == 0
+                || canFind(timed.output, "may not be deterministic");
+            if (!measured) {
+                stderr.writefln("  build FAILED %s — skipping", flake);
+                continue;
+            }
+            const secs = timed.elapsed.total!"seconds";
+            weights.require(system, SystemWeights.init)
+                .families.require(rep.family, null)[cast(Variant) doCheck] =
+                secs < 1 ? 1 : secs;
+            stderr.writefln("  %s %s (doCheck=%s) -> %ss",
+                sysStr, rep.family, doCheck, secs);
+        }
+        // `default` (unknown family) = cheapest measured class in the system.
+        long minW = long.max;
+        if (auto sys = system in weights)
+            foreach (_, variants; sys.families)
+                foreach (_v, v; variants)
+                    if (v < minW)
+                        minW = v;
+        if (minW != long.max)
+            weights.require(system, SystemWeights.init).defaultWeight = minW;
+    }
+
+    std.file.write(output, toSortedPrettyJson(weightsToJson(weights)) ~ "\n");
+    stderr.writefln("Wrote %s", output);
+}
+
+/// `Weights` -> JSONValue (scalar `default` + `family -> {variant: weight}`).
+private JSONValue weightsToJson(Weights w) {
+    JSONValue[string] outer;
+    foreach (system, sw; w) {
+        JSONValue[string] mid;
+        mid["default"] = JSONValue(sw.defaultWeight);
+        foreach (family, variants; sw.families) {
+            JSONValue[string] inner;
+            foreach (variant, v; variants)
+                inner[variant.to!string] = JSONValue(v);
+            mid[family] = JSONValue(inner);
+        }
+        outer[system] = JSONValue(mid);
+    }
+    return JSONValue(outer);
+}

--- a/src/dlang_nix/ci/weights.d
+++ b/src/dlang_nix/ci/weights.d
@@ -1,0 +1,209 @@
+module dlang_nix.ci.weights;
+
+// Build-time cost model + bin-packing for the CI build matrix.
+//
+// GitHub caps a job matrix at 256 entries, but the cold-cache build list is
+// larger (every uncached, buildable `(package, system)`), so we pack several
+// cheap packages into one job while letting heavy compiler builds keep their
+// own. Packing is driven by a *relative build-time weight* per package; the
+// weights themselves are measured by the `dlang-nix-fetcher ci calibrate`
+// subcommand (see `dlang_nix.ci.cli`) and committed to
+// `scripts/ci-build-weights.json`.
+//
+// The packer is deliberately identity-agnostic: it sees only a flat
+// `WeightedItem` (a display `name`, a retargetable `attrPath`, a runner, and a
+// `weight`). The rich `PackageBuildTarget` modelling lives at the boundary in
+// `dlang_nix.ci.cli`, which projects down to these items.
+
+import std.algorithm : filter, map, maxElement, sort, uniq;
+import std.array : array, empty, join;
+
+import dlang_nix.utils.conv : parseEnum;
+
+@safe:
+
+/// A Nix system double (`<arch>-<os>`). String-backed so each member *is* its
+/// canonical double: it converts straight to `string` for flake refs and JSON
+/// keys. Parse the reverse with `parseEnum!NixSystem`.
+enum NixSystem : string {
+    x86_64_linux = "x86_64-linux",
+    aarch64_linux = "aarch64-linux",
+    x86_64_darwin = "x86_64-darwin",
+    aarch64_darwin = "aarch64-darwin",
+    i686_linux = "i686-linux",
+}
+
+@("dlang_nix.ci.weights.nixSystem")
+unittest {
+    assert(NixSystem.x86_64_linux == "x86_64-linux");
+    assert("aarch64-darwin".parseEnum!NixSystem == NixSystem.aarch64_darwin);
+    assert("i686-linux".parseEnum!NixSystem == NixSystem.i686_linux);
+    foreach (s; [NixSystem.x86_64_linux, NixSystem.aarch64_darwin, NixSystem.i686_linux])
+        assert((cast(string) s).parseEnum!NixSystem == s); // round-trips
+}
+
+/// Whether a package was built with its test suite (`doCheck`). A checked build
+/// can cost an order of magnitude more than a plain one, so weights are tracked
+/// per variant. Backed by `bool` so it converts straight from a `doCheck` flag
+/// (`cast(Variant) doCheck`); the member names double as the on-disk JSON keys.
+enum Variant : bool {
+    build, // doCheck = false
+    test, // doCheck = true
+}
+
+/// Per-system weights: a `default` fallback plus `family -> variant -> weight`.
+/// A family only lists the variant(s) it actually has.
+struct SystemWeights {
+    long defaultWeight = 1;
+    long[Variant][string] families;
+}
+
+/// `system -> SystemWeights`.
+alias Weights = SystemWeights[NixSystem];
+
+/// Looks up a package's weight: its family's matching variant, else whatever
+/// variant the family does have, else the system `default`, else `1` (so an
+/// unknown family is never zero-weighted, which would let unbounded numbers of
+/// them pack into a single job).
+long weightOf(const Weights w, NixSystem system, string family, Variant variant) pure {
+    const sys = system in w;
+    if (sys is null)
+        return 1;
+    if (auto fam = family in sys.families) {
+        if (auto v = variant in *fam)
+            return *v;
+        return fam.byValue.front; // family has only the other variant — close enough
+    }
+    return sys.defaultWeight;
+}
+
+@("dlang_nix.ci.weights.weightOf")
+unittest {
+    Weights w;
+    SystemWeights sw;
+    sw.defaultWeight = 6;
+    sw.families["ldc"][Variant.build] = 87;
+    sw.families["dub"][Variant.build] = 6;
+    sw.families["dub"][Variant.test] = 139;
+    w[NixSystem.x86_64_linux] = sw;
+
+    assert(weightOf(w, NixSystem.x86_64_linux, "ldc", Variant.build) == 87);
+    assert(weightOf(w, NixSystem.x86_64_linux, "dub", Variant.test) == 139);
+    assert(weightOf(w, NixSystem.x86_64_linux, "dub", Variant.build) == 6);
+    assert(weightOf(w, NixSystem.x86_64_linux, "dmd-binary", Variant.build) == 6); // default
+    assert(weightOf(w, NixSystem.x86_64_linux, "ldc", Variant.test) == 87); // falls back to build
+    assert(weightOf(w, NixSystem.aarch64_darwin, "ldc", Variant.test) == 1); // unknown system
+}
+
+/// One buildable atom, projected from a `PackageBuildTarget` for packing.
+/// `name` is the display label (e.g. a job name); `attrPath` is the retargetable
+/// flake attribute path (`packages.<system>.<attr>`, no `.#`).
+struct WeightedItem {
+    string name;
+    string attrPath;
+    NixSystem system;
+    string os; // GH runner, e.g. "ubuntu-latest"
+    long weight;
+}
+
+/// One CI job: a set of items built together on a runner.
+struct Bin {
+    string os;
+    NixSystem system;
+    WeightedItem[] items;
+    long load;
+}
+
+/// First-Fit-Decreasing pack of one system's items into bins of capacity
+/// `cap`. An item whose weight reaches `cap` fills its bin alone (nothing
+/// else fits) — which is exactly "a heavy build gets a dedicated job" once the
+/// caller sets `cap == maxWeight`.
+///
+/// FFD is a genuinely stateful algorithm (each placement depends on the running
+/// loads of every prior bin), so this stays an explicit loop rather than a
+/// range pipeline.
+Bin[] packSystem(WeightedItem[] items, long cap) pure {
+    auto sorted = items.dup.sort!((a, b) => a.weight > b.weight);
+    Bin[] bins;
+    outer: foreach (p; sorted) {
+        foreach (ref b; bins)
+            if (b.load + p.weight <= cap) {
+                b.items ~= p;
+                b.load += p.weight;
+                continue outer;
+            }
+        bins ~= Bin(p.os, p.system, [p], p.weight);
+    }
+    return bins;
+}
+
+@("dlang_nix.ci.weights.packSystem")
+unittest {
+    WeightedItem wp(string a, long w) =>
+        WeightedItem(a, a, NixSystem.x86_64_linux, "ubuntu-latest", w);
+
+    // Heaviest (== cap) stays solo; the two 50s share one bin.
+    auto bins = packSystem([wp("a", 100), wp("b", 50), wp("c", 50)], 100);
+    assert(bins.length == 2);
+    assert(bins[0].items.map!(i => i.name).array == ["a"] && bins[0].load == 100);
+    assert(bins[1].load == 100); // b + c
+
+    // Many light packages pack densely under a generous cap.
+    auto light = packSystem([wp("a", 1), wp("b", 1), wp("c", 1), wp("d", 1), wp("e", 1)], 3);
+    assert(light.length == 2); // [3] + [2]
+    foreach (b; light)
+        assert(b.load <= 3);
+}
+
+/// Groups items by system, packs each with capacity `= maxWeight` (so the
+/// makespan is ~one longest build and the heaviest builds are isolated), and
+/// guards the global job count: if it would exceed `capLimit`, capacities are
+/// scaled up uniformly and everything is repacked until it fits.
+Bin[] planMatrix(WeightedItem[] items, long capLimit = 240) pure {
+    auto systems = items.map!(p => p.system).array.sort.uniq.array;
+    for (long scale = 1;; scale++) {
+        auto bins = systems
+            .map!(sys => items.filter!(p => p.system == sys).array)
+            .filter!(sp => !sp.empty)
+            .map!(sp => packSystem(sp, sp.map!(p => p.weight).maxElement * scale))
+            .join;
+        if (bins.length <= capLimit || items.length <= capLimit)
+            return bins;
+    }
+}
+
+@("dlang_nix.ci.weights.planMatrix")
+unittest {
+    import std.algorithm : sort, map;
+    import std.array : array, join;
+
+    WeightedItem p(string a, NixSystem sys, long w) {
+        const os = sys == NixSystem.x86_64_linux ? "ubuntu-latest" : "macos-latest";
+        return WeightedItem(a, a, sys, os, w);
+    }
+
+    auto items = [
+        p("ldc-1", NixSystem.x86_64_linux, 100),
+        p("dmd-1", NixSystem.x86_64_linux, 80),
+        p("dub-1", NixSystem.x86_64_linux, 9),
+        p("dub-2", NixSystem.x86_64_linux, 9),
+        p("ldc-binary-1", NixSystem.x86_64_linux, 1),
+        p("ldc-2", NixSystem.aarch64_darwin, 100),
+        p("dub-3", NixSystem.aarch64_darwin, 9),
+    ];
+    auto bins = planMatrix(items);
+
+    // Every item appears exactly once (nothing lost or duplicated).
+    auto packed = bins.map!(b => b.items.map!(i => i.name).array).join.array.sort.array;
+    auto input = items.map!(p => p.name).array.sort.array;
+    assert(packed == input);
+
+    // No bin exceeds its system's capacity (== that system's max weight here).
+    foreach (b; bins)
+        assert(b.load <= 100);
+
+    // The heavy compiler builds are isolated.
+    foreach (b; bins)
+        if (b.items.length == 1 && (b.items[0].name == "ldc-1" || b.items[0].name == "ldc-2"))
+            assert(b.load >= 100);
+}

--- a/src/dlang_nix/components.d
+++ b/src/dlang_nix/components.d
@@ -1,128 +1,316 @@
 module dlang_nix.components;
 
-import std.array : split, join;
-import std.algorithm : startsWith;
+import std.algorithm : findSplitBefore, startsWith;
+import std.array : array, join, replace, split;
+import std.ascii : isDigit;
 import std.conv : to;
 import std.format : format;
+import std.meta : AliasSeq, allSatisfy;
 import std.path : buildNormalizedPath, dirName;
+import std.string : representation;
+import std.typecons : Nullable;
 
-import sparkles.versions : SemVer, Dmd;
+import sparkles.versions : SemVer;
+import sparkles.versions : DmdVer = Dmd;
+import sparkles.versions.traits : isVersionScheme;
 
-import dlang_nix.utils.commands : Hash, Url, resolveTagRevs, resolveVersionRange;
+import dlang_nix.utils.commands : Hash, Url;
 
-alias Version = string;
+/// A download platform token as the upstream URL scheme spells it
+/// (`"linux"`, `"osx-x86_64"`, or a source-archive repo name like `"phobos"`).
+/// Distinct from a Nix system double (`dlang_nix.ci.weights.NixSystem`).
 alias Platform = string;
 
-/// Resolves a `[first, last]` minor range into an explicit version list,
-/// emitting each version in the component's native tag form. DMD uses a
-/// zero-padded 3-digit minor (`2.070.0`); LDC follows canonical SemVer.
-/// Impure (`@system`) since it shells out for tag discovery, hence declared
-/// outside the module's `@safe pure:` region.
-alias VersionRangeResolver =
-    Version[] function(string tagsRepo, string first, string last);
-
-/// Resolves each requested version to the commit hash its release tag
-/// points to (for fetchers that pin an explicit `rev`). Impure
-/// (`@system`) since it shells out to `git ls-remote`.
-alias RevResolver =
-    Hash[Version] function(string tagsRepo, const Version[] versions);
-
-@safe pure:
-
-enum Component { dmd, dmd_src, ldc, ldc_src, dub };
-
-alias UrlFormatter = Url function(Platform platform, Version compilerVersion);
-
-alias PlatformQuery = Platform[] function(Version);
-
+/// Whether an archive must be unpacked after fetching.
 enum UnpackingNeeded : bool { no, yes }
 
-struct ComponentInfo {
-    UrlFormatter urlFormatter;
-    PlatformQuery platforms;
-    UnpackingNeeded unpackingNeed;
-    string supportedVersionsFile;
-    string tagsRepo;   // "owner/repo" on GitHub for tag discovery
-    Version[] defaultVersions;  // fetched when no versions are requested
-    VersionRangeResolver resolveVersions;
-    RevResolver resolveRevs;  // set when the nix fetcher pins an explicit rev
+// ---------------------------------------------------------------------------
+// The PackageFamily concept
+//
+// A package family is a plain struct conforming to `isPackageFamily!C`, in the
+// spirit of `sparkles:versions` (a scheme is "a struct + a static assert, no
+// base class, no registration"). It carries its attr-prefix `name`, the
+// `VersionType` its tags follow, and the static fetch surface that used to live
+// in the `ComponentInfo` function-pointer table.
+// ---------------------------------------------------------------------------
+
+/// Exercises the required surface so a failed `isPackageFamily` can be
+/// diagnosed by instantiating `checkPackageFamily!C` directly.
+void checkPackageFamily(C)() {
+    string n = C.name;
+    assert(n.length);
+    static assert(isVersionScheme!(C.VersionType));
+    alias V = C.VersionType;
+    Url u = C.url(Platform.init, V.init);
+    Platform[] ps = C.platforms(V.init);
+    UnpackingNeeded un = C.unpackingNeed;
+    string f = C.supportedVersionsFile;
+    string r = C.tagsRepo;
+    V[] dv = C.defaultVersions;
 }
+
+/// True for a struct that models a package family.
+enum isPackageFamily(C) = is(typeof(checkPackageFamily!C));
+
+/// Optional capability: a family that pins the commit each release tag points
+/// to (only `Dub`). Detected like the `sparkles:versions` optional traits.
+template familyPinsRev(C) {
+    static if (__traits(hasMember, C, "pinsRev"))
+        enum familyPinsRev = C.pinsRev;
+    else
+        enum familyPinsRev = false;
+}
+
+@safe:
 
 string suffix(Platform p) => p.startsWith("windows") ? "7z" : "tar.xz";
 
 enum pkgsDir = __FILE_FULL_PATH__.dirName.buildNormalizedPath("..", "..", "pkgs");
 
-enum ComponentInfo[Component] supportedPlatforms = [
-    Component.dmd: ComponentInfo(
-        urlFormatter: (platform, compilerVersion) =>
-            "http://downloads.dlang.org/releases/2.x/%s/dmd.%s.%s.%s"
-                .format(compilerVersion, compilerVersion, platform, suffix(platform)),
-        platforms: compVersion => [
-            "linux", "osx", "freebsd-64", "windows"
-        ],
-        unpackingNeed: UnpackingNeeded.no,
-        supportedVersionsFile: pkgsDir.buildNormalizedPath("dmd", "supported-binary-versions.json"),
-        tagsRepo: "dlang/dmd",
-        defaultVersions: [ "2.105.0" ],
-        resolveVersions: &resolveVersionRange!Dmd,
-    ),
-    Component.dmd_src: ComponentInfo(
-        urlFormatter: (platform, compilerVersion) =>
-            "https://github.com/dlang/%s/archive/refs/tags/v%s.tar.gz"
-                .format(platform, compilerVersion),
-        platforms: compVersion => [
-            ["dmd"],
-            compVersion.split(".")[1].to!int >= 101 ? [] : ["druntime"],
-            ["phobos", "tools"]
-        ].join,
-        unpackingNeed: UnpackingNeeded.yes,
-        supportedVersionsFile: pkgsDir.buildNormalizedPath("dmd", "supported-source-versions.json"),
-        tagsRepo: "dlang/dmd",
-        defaultVersions: [ "2.105.0" ],
-        resolveVersions: &resolveVersionRange!Dmd,
-    ),
-    Component.ldc: ComponentInfo(
-        urlFormatter: (platform, compilerVersion) =>
-            "https://github.com/ldc-developers/ldc/releases/download/v%s/ldc2-%s-%s.%s"
-                .format(compilerVersion, compilerVersion, platform, suffix(platform)),
-        platforms: compVersion => [
-            "android-aarch64", "android-armv7a",
-            "freebsd-x86_64",
-            "linux-aarch64", "linux-x86_64",
-            "osx-arm64", "osx-x86_64",
-            "windows-x64", "windows-x86"
-        ],
-        unpackingNeed: UnpackingNeeded.no,
-        supportedVersionsFile: pkgsDir.buildNormalizedPath("ldc", "supported-binary-versions.json"),
-        tagsRepo: "ldc-developers/ldc",
-        defaultVersions: [ "1.35.0" ],
-        resolveVersions: &resolveVersionRange!SemVer,
-    ),
-    Component.ldc_src: ComponentInfo(
-        urlFormatter: (platform, compilerVersion) =>
-            "https://github.com/ldc-developers/ldc/releases/download/v%s/ldc-%s-src.tar.gz"
-                .format(compilerVersion, compilerVersion),
-        platforms: compVersion => [
-            "src"
-        ],
-        unpackingNeed: UnpackingNeeded.no,
-        supportedVersionsFile: pkgsDir.buildNormalizedPath("ldc", "supported-source-versions.json"),
-        tagsRepo: "ldc-developers/ldc",
-        defaultVersions: [ "1.35.0" ],
-        resolveVersions: &resolveVersionRange!SemVer,
-    ),
-    Component.dub: ComponentInfo(
-        urlFormatter: (platform, compilerVersion) =>
-            "https://github.com/dlang/%s/archive/refs/tags/v%s.tar.gz"
-                .format(platform, compilerVersion),
-        platforms: compVersion => [
-            "dub"
-        ],
-        unpackingNeed: UnpackingNeeded.yes,
-        supportedVersionsFile: pkgsDir.buildNormalizedPath("dub", "supported-source-versions.json"),
-        tagsRepo: "dlang/dub",
-        defaultVersions: [ "1.41.0" ],
-        resolveVersions: &resolveVersionRange!SemVer,
-        resolveRevs: &resolveTagRevs,
-    ),
-];
+// ---------------------------------------------------------------------------
+// The five families. Source builds take no suffix; the binary variant is
+// suffixed `-binary`. The `name` is the attr/pname prefix (and CI weight key).
+// ---------------------------------------------------------------------------
+
+/// DMD binary releases from downloads.dlang.org.
+struct DmdBinary {
+    enum string name = "dmd-binary";
+    alias VersionType = DmdVer;
+
+    static Url url(Platform platform, VersionType v) {
+        const vs = v.to!string;
+        return "http://downloads.dlang.org/releases/2.x/%s/dmd.%s.%s.%s"
+            .format(vs, vs, platform, suffix(platform));
+    }
+
+    static Platform[] platforms(VersionType) => ["linux", "osx", "freebsd-64", "windows"];
+
+    enum UnpackingNeeded unpackingNeed = UnpackingNeeded.no;
+    enum string supportedVersionsFile =
+        pkgsDir.buildNormalizedPath("dmd", "supported-binary-versions.json");
+    enum string tagsRepo = "dlang/dmd";
+
+    static VersionType[] defaultVersions() => [VersionType(2, 105, 0)];
+
+    static assert(isPackageFamily!DmdBinary);
+}
+
+/// DMD built from source (dmd/druntime/phobos/tools GitHub archives).
+struct Dmd {
+    enum string name = "dmd";
+    alias VersionType = DmdVer;
+
+    static Url url(Platform platform, VersionType v) =>
+        "https://github.com/dlang/%s/archive/refs/tags/v%s.tar.gz"
+            .format(platform, v.to!string);
+
+    // druntime merged into dmd at 2.101, so it is a separate archive only
+    // before then.
+    static Platform[] platforms(VersionType v) => [
+        ["dmd"],
+        v.minor >= 101 ? cast(string[])[] : ["druntime"],
+        ["phobos", "tools"],
+    ].join;
+
+    enum UnpackingNeeded unpackingNeed = UnpackingNeeded.yes;
+    enum string supportedVersionsFile =
+        pkgsDir.buildNormalizedPath("dmd", "supported-source-versions.json");
+    enum string tagsRepo = "dlang/dmd";
+
+    static VersionType[] defaultVersions() => [VersionType(2, 105, 0)];
+
+    static assert(isPackageFamily!Dmd);
+}
+
+/// LDC binary releases from GitHub.
+struct LdcBinary {
+    enum string name = "ldc-binary";
+    alias VersionType = SemVer;
+
+    static Url url(Platform platform, VersionType v) {
+        const vs = v.to!string;
+        return "https://github.com/ldc-developers/ldc/releases/download/v%s/ldc2-%s-%s.%s"
+            .format(vs, vs, platform, suffix(platform));
+    }
+
+    static Platform[] platforms(VersionType) => [
+        "android-aarch64", "android-armv7a",
+        "freebsd-x86_64",
+        "linux-aarch64", "linux-x86_64",
+        "osx-arm64", "osx-x86_64",
+        "windows-x64", "windows-x86",
+    ];
+
+    enum UnpackingNeeded unpackingNeed = UnpackingNeeded.no;
+    enum string supportedVersionsFile =
+        pkgsDir.buildNormalizedPath("ldc", "supported-binary-versions.json");
+    enum string tagsRepo = "ldc-developers/ldc";
+
+    static VersionType[] defaultVersions() => [VersionType(1, 35, 0)];
+
+    static assert(isPackageFamily!LdcBinary);
+}
+
+/// LDC built from the release source tarball.
+struct Ldc {
+    enum string name = "ldc";
+    alias VersionType = SemVer;
+
+    static Url url(Platform, VersionType v) {
+        const vs = v.to!string;
+        return "https://github.com/ldc-developers/ldc/releases/download/v%s/ldc-%s-src.tar.gz"
+            .format(vs, vs);
+    }
+
+    static Platform[] platforms(VersionType) => ["src"];
+
+    enum UnpackingNeeded unpackingNeed = UnpackingNeeded.no;
+    enum string supportedVersionsFile =
+        pkgsDir.buildNormalizedPath("ldc", "supported-source-versions.json");
+    enum string tagsRepo = "ldc-developers/ldc";
+
+    static VersionType[] defaultVersions() => [VersionType(1, 35, 0)];
+
+    static assert(isPackageFamily!Ldc);
+}
+
+/// dub built from its GitHub source archive. Pins an explicit `rev`.
+struct Dub {
+    enum string name = "dub";
+    alias VersionType = SemVer;
+
+    static Url url(Platform platform, VersionType v) =>
+        "https://github.com/dlang/%s/archive/refs/tags/v%s.tar.gz"
+            .format(platform, v.to!string);
+
+    static Platform[] platforms(VersionType) => ["dub"];
+
+    enum UnpackingNeeded unpackingNeed = UnpackingNeeded.yes;
+    enum string supportedVersionsFile =
+        pkgsDir.buildNormalizedPath("dub", "supported-source-versions.json");
+    enum string tagsRepo = "dlang/dub";
+
+    static VersionType[] defaultVersions() => [VersionType(1, 41, 0)];
+
+    /// Optional capability: the nix fetcher pins the tag's commit.
+    enum bool pinsRev = true;
+
+    static assert(isPackageFamily!Dub);
+}
+
+/// The single registry: CLI tokens, dispatch, and allowed-value help are all
+/// inferred from this list via `F.name`.
+alias Families = AliasSeq!(DmdBinary, Dmd, LdcBinary, Ldc, Dub);
+static assert(allSatisfy!(isPackageFamily, Families));
+
+// ---------------------------------------------------------------------------
+// baseFamily — the family matcher
+// ---------------------------------------------------------------------------
+
+/// A package "family" is the attr name with its trailing `-<version>` removed.
+/// Versions are sanitised to digits/underscores, so the version always starts
+/// at the first `-` immediately followed by a digit. Names without such a
+/// marker (the unversioned aliases like `ldc-bootstrap`) are returned as-is.
+string baseFamily(string pkg) pure nothrow {
+    // Split before the first `-<digit>`. The needle `"-0"` matches positionally:
+    // its `-` must match a literal `-`, while the `0` placeholder stands for any
+    // digit. With no such marker, `findSplitBefore` yields the whole name in [0].
+    // Operate on the byte `representation` so `find` doesn't auto-decode UTF
+    // (which would throw and break `nothrow`).
+    const fam = pkg.representation
+        .findSplitBefore!((h, n) => n == '-' ? h == '-' : h.isDigit)("-0".representation);
+    return cast(string) fam[0];
+}
+
+@("dlang_nix.components.baseFamily")
+unittest {
+    assert(baseFamily("dmd-2_112_0") == "dmd");
+    assert(baseFamily("dmd-binary-2_098_0") == "dmd-binary");
+    assert(baseFamily("ldc-binary-1_42_0-beta2") == "ldc-binary");
+    assert(baseFamily("dub-1_43_0-alpha-5efed36") == "dub");
+    assert(baseFamily("ldc-bootstrap") == "ldc-bootstrap");
+    assert(baseFamily("dub") == "dub");
+}
+
+// ---------------------------------------------------------------------------
+// PackageRelease — a family at a concrete version
+// ---------------------------------------------------------------------------
+
+/// A package family resolved to a version: `family + version`. The verbatim
+/// `rawVersion` (underscore form, as it appears in the Nix attr) backs an exact
+/// `toString` round-trip; `ver` is the best-effort typed parse used for
+/// ordering, empty for unversioned aliases or an unparseable version.
+struct PackageRelease(C) if (isPackageFamily!C) {
+    alias Family = C;
+
+    string rawVersion; // "2_098_0", or "" when the attr is bare (`dmd`)
+    Nullable!(C.VersionType) ver;
+
+    /// Splits an attr (`baseFamily(attr) == C.name` required) into the verbatim
+    /// version remainder and a best-effort typed parse.
+    static PackageRelease parse(string attr) {
+        PackageRelease r;
+        if (attr.length > C.name.length) {
+            assert(attr[0 .. C.name.length] == C.name && attr[C.name.length] == '-',
+                "attr '" ~ attr ~ "' is not in family '" ~ C.name ~ "'");
+            r.rawVersion = attr[C.name.length + 1 .. $];
+            auto p = C.VersionType.parse(r.rawVersion.replace("_", "."));
+            if (p.hasValue)
+                r.ver = p.value;
+        } else
+            assert(attr == C.name, "attr '" ~ attr ~ "' is not family '" ~ C.name ~ "'");
+        return r;
+    }
+
+    /// Reconstructs the Nix attr name exactly.
+    string toString() const => rawVersion.length ? C.name ~ "-" ~ rawVersion : C.name;
+
+    /// Total order by version (a versionless release sorts first), tie-broken
+    /// by the raw string so distinct attrs never compare equal.
+    int opCmp(in PackageRelease o) const {
+        import std.algorithm.comparison : cmp;
+
+        if (ver.isNull != o.ver.isNull)
+            return ver.isNull ? -1 : 1;
+        if (!ver.isNull)
+            if (const c = ver.get.opCmp(o.ver.get))
+                return c;
+        return cmp(rawVersion, o.rawVersion);
+    }
+
+    bool opEquals(in PackageRelease o) const => rawVersion == o.rawVersion;
+
+    size_t toHash() const @trusted pure nothrow {
+        import core.internal.hash : hashOf;
+
+        return hashOf(rawVersion);
+    }
+}
+
+@("dlang_nix.components.PackageRelease")
+unittest {
+    // Round-trips exactly, and parses the typed version under the family scheme.
+    auto d = PackageRelease!DmdBinary.parse("dmd-binary-2_098_0");
+    assert(d.toString == "dmd-binary-2_098_0");
+    assert(!d.ver.isNull && d.ver.get == DmdVer(2, 98, 0));
+
+    auto l = PackageRelease!Ldc.parse("ldc-1_42_0");
+    assert(l.toString == "ldc-1_42_0");
+    assert(!l.ver.isNull && l.ver.get == SemVer(1, 42, 0));
+
+    // A prerelease with a hyphenated identifier round-trips.
+    auto b = PackageRelease!LdcBinary.parse("ldc-binary-1_42_0-beta2");
+    assert(b.toString == "ldc-binary-1_42_0-beta2");
+    assert(!b.ver.isNull);
+
+    // Bare alias: no version, still round-trips.
+    auto bare = PackageRelease!Dmd.parse("dmd");
+    assert(bare.toString == "dmd");
+    assert(bare.ver.isNull);
+
+    // Ordering by version, with raw-string tie-break and versionless-first.
+    auto lo = PackageRelease!Ldc.parse("ldc-1_40_0");
+    auto hi = PackageRelease!Ldc.parse("ldc-1_42_0");
+    assert(lo < hi);
+    assert(PackageRelease!Ldc.parse("ldc") < lo); // versionless sorts first
+}

--- a/src/dlang_nix/utils/commands.d
+++ b/src/dlang_nix/utils/commands.d
@@ -54,6 +54,24 @@ string executeCommand(bool dryRun, string command) {
     return result.status == 0 ? result.output : null;
 }
 
+import core.time : Duration;
+import std.datetime.stopwatch : StopWatch, AutoStart;
+
+alias TimedResult = Tuple!(int, "status", Duration, "elapsed", string, "output");
+
+/// Runs `command`, capturing its combined output, and returns the exit status,
+/// wall-clock time and output. Used by `calibrate` to measure per-package build
+/// times (the output lets it tell a real build failure from `nix build
+/// --rebuild`'s "may not be deterministic" mismatch, which still timed a real
+/// build).
+TimedResult executeTimed(string command) {
+    stderr.writefln(`> %s`, command);
+    auto sw = StopWatch(AutoStart.yes);
+    const result = executeShell(command, null, Config.none);
+    sw.stop();
+    return TimedResult(result.status, sw.peek, result.output);
+}
+
 // ---------------------------------------------------------------------------
 // Version predicates and selectors.
 //
@@ -86,6 +104,7 @@ if (hasSemVerComponents!V) {
         .array;
 }
 
+@("dlang_nix.utils.commands.semverHelpers")
 unittest {
     import sparkles.versions : SemVer, Dmd;
 
@@ -164,29 +183,32 @@ TagRev[] fetchTags(string repo) {
 
 /// Resolves each requested version to the commit hash its `v<version>`
 /// release tag points to (for fetchers that pin an explicit `rev`).
-string[string] resolveTagRevs(string tagsRepo, const string[] versions) {
+/// Parameterised over a `sparkles:versions` scheme; the result is keyed by the
+/// version's canonical `toString` (the JSON/serialization boundary).
+Hash[string] resolveTagRevs(Scheme)(string tagsRepo, const Scheme[] versions) {
     const tagRevs = fetchTags(tagsRepo);
-    string[string] revs;
+    Hash[string] revs;
     foreach (ver; versions) {
-        const tag = "v" ~ ver;
+        const vs = ver.to!string;
+        const tag = "v" ~ vs;
         auto hit = tagRevs.find!(tr => tr.tag == tag);
         enforce(!hit.empty,
             "No tag " ~ tag ~ " found in repo " ~ tagsRepo);
-        revs[ver] = hit.front.rev;
+        revs[vs] = hit.front.rev;
     }
     return revs;
 }
 
 /// Resolves an inclusive `[first, last]` minor range against the tags of
 /// the given GitHub repo and returns the highest-patch stable release for
-/// each minor, as version strings sorted ascending. An empty `last` means
-/// "latest available stable tag".
+/// each minor, as typed `Scheme` versions sorted ascending. An empty `last`
+/// means "latest available stable tag".
 ///
 /// Parameterised over a sparkles:versions scheme (e.g. `SemVer` for LDC's
-/// canonical tags, `Dmd` for DMD's zero-padded minor convention). The
-/// returned strings use the scheme's `toString`, so DMD comes back as
-/// `"2.079.0"` and LDC as `"1.42.0"`.
-string[] resolveVersionRange(Scheme)(string tagsRepo, string first, string last) {
+/// canonical tags, `Dmd` for DMD's zero-padded minor convention). Callers
+/// `toString` at the serialization boundary (DMD renders `"2.079.0"`, LDC
+/// `"1.42.0"`).
+Scheme[] resolveVersionRange(Scheme)(string tagsRepo, string first, string last) {
     // `.value` on a parse-failed Expected throws — what we want for user
     // input.
     const lo = Scheme.parseLoose(first).value;
@@ -211,7 +233,7 @@ string[] resolveVersionRange(Scheme)(string tagsRepo, string first, string last)
         .latestPatchPerMinor;
 
     vers.sort!((a, b) => a < b);  // ascending for user display
-    return vers.map!(v => v.to!string).array;
+    return vers;
 }
 
 /// Pure: parses the output of `git ls-remote --tags <url>` into a list of
@@ -240,6 +262,7 @@ TagRev[] parseGitLsRemoteTags(string output) @safe pure {
 }
 
 // editorconfig-checker-disable
+@("dlang_nix.utils.commands.parseGitLsRemoteTags")
 unittest {
     // Mixed peeled / non-peeled, junk lines, non-version tags. The peeled
     // `^{}` hash replaces the annotated tag object's hash; lightweight

--- a/src/dlang_nix/utils/conv.d
+++ b/src/dlang_nix/utils/conv.d
@@ -1,0 +1,37 @@
+module dlang_nix.utils.conv;
+
+import std.conv : ConvException;
+import std.traits : EnumMembers;
+
+@safe:
+
+/// Parses a string into enum `E` by matching member *values*. Unlike
+/// `std.conv.to!E`, which matches member *names*, this suits string-backed enums
+/// whose value differs from the identifier (e.g. `NixSystem.x86_64_linux ==
+/// "x86_64-linux"`). The `static foreach` expands one `case` per member, so the
+/// compiler builds a string switch.
+E parseEnum(E)(string s) pure if (is(E == enum)) {
+    switch (s) {
+        static foreach (member; EnumMembers!E)
+    case member:
+            return member;
+    default:
+        throw new ConvException("invalid " ~ E.stringof ~ ": " ~ s);
+    }
+}
+
+@("dlang_nix.utils.conv.parseEnum")
+unittest {
+    enum Color : string {
+        red = "red",
+        deepBlue = "deep-blue",
+    }
+
+    assert(parseEnum!Color("red") == Color.red);
+    assert(parseEnum!Color("deep-blue") == Color.deepBlue);
+
+    import std.exception : assertThrown;
+
+    assertThrown!ConvException(parseEnum!Color("deepBlue")); // matches value, not name
+    assertThrown!ConvException(parseEnum!Color("green"));
+}

--- a/src/dlang_nix/utils/json.d
+++ b/src/dlang_nix/utils/json.d
@@ -10,14 +10,14 @@ import std.uni : isControl;
 
 import sparkles.versions : SemVer;
 
-import dlang_nix.components : Platform, Version;
+import dlang_nix.components : Platform;
 import dlang_nix.utils.commands : Hash;
 
-/// Converts a `Hash[Platform][Version]` AA into a JSONValue, mapping null
+/// Converts a `Hash[Platform][string]` AA into a JSONValue, mapping null
 /// or empty Hash values to JSON `null`. Done manually because D's std.json
 /// otherwise renders a null `string` as the JSON string `""`, masking the
 /// "unsupported on this platform" sentinel.
-JSONValue hashesToJsonValue(Hash[Platform][Version] hashes) {
+JSONValue hashesToJsonValue(Hash[Platform][string] hashes) {
     JSONValue[string] outer;
     foreach (ver, platforms; hashes) {
         JSONValue[string] inner;
@@ -33,8 +33,8 @@ JSONValue hashesToJsonValue(Hash[Platform][Version] hashes) {
 /// returns the result rendered as pretty JSON with a trailing newline.
 /// New entries overwrite existing version/platform pairs. Existing `null`
 /// or `""` entries are preserved as the null sentinel.
-string mergeHashesIntoJson(string existingJson, Hash[Platform][Version] newHashes) {
-    Hash[Platform][Version] allHashes;
+string mergeHashesIntoJson(string existingJson, Hash[Platform][string] newHashes) {
+    Hash[Platform][string] allHashes;
     if (existingJson.length > 0) {
         auto existing = parseJSON(existingJson);
         foreach (string ver, platforms; existing.object) {
@@ -60,9 +60,10 @@ string mergeHashesIntoJson(string existingJson, Hash[Platform][Version] newHashe
 // drops the leading newline that the backtick-on-its-own-line syntax adds.
 
 // editorconfig-checker-disable
+@("dlang_nix.utils.json.mergeHashesIntoJson")
 unittest {
     // Empty existing JSON: only new hashes appear.
-    Hash[Platform][Version] h1;
+    Hash[Platform][string] h1;
     h1["1.0.0"]["linux"] = "sha256-abc";
     assert(mergeHashesIntoJson("", h1) == outdent(`
         {
@@ -73,7 +74,7 @@ unittest {
     `)[1 .. $]);
 
     // Non-overlapping versions are unioned.
-    Hash[Platform][Version] h2;
+    Hash[Platform][string] h2;
     h2["2.0.0"]["linux"] = "sha256-new";
     assert(mergeHashesIntoJson(
         `{"1.0.0": {"linux": "sha256-old"}}`, h2) == outdent(`
@@ -88,7 +89,7 @@ unittest {
     `)[1 .. $]);
 
     // Overlapping version/platform: new value overwrites existing.
-    Hash[Platform][Version] h3;
+    Hash[Platform][string] h3;
     h3["1.0.0"]["linux"] = "sha256-new";
     assert(mergeHashesIntoJson(
         `{"1.0.0": {"linux": "sha256-old"}}`, h3) == outdent(`
@@ -100,7 +101,7 @@ unittest {
     `)[1 .. $]);
 
     // Same version, disjoint platforms: platforms are merged and sorted.
-    Hash[Platform][Version] h4;
+    Hash[Platform][string] h4;
     h4["1.0.0"]["osx"] = "sha256-osx";
     assert(mergeHashesIntoJson(
         `{"1.0.0": {"linux": "sha256-linux"}}`, h4) == outdent(`
@@ -113,7 +114,7 @@ unittest {
     `)[1 .. $]);
 
     // Null Hash from a failed prefetch renders as JSON null, not `""`.
-    Hash[Platform][Version] h5;
+    Hash[Platform][string] h5;
     h5["1.0.0"]["linux"] = "sha256-linux";
     h5["1.0.0"]["freebsd"] = null;
     assert(mergeHashesIntoJson("", h5) == outdent(`
@@ -126,7 +127,7 @@ unittest {
     `)[1 .. $]);
 
     // Legacy `""` entries in existing JSON are normalized to JSON null.
-    Hash[Platform][Version] h6;
+    Hash[Platform][string] h6;
     assert(mergeHashesIntoJson(
         `{"1.0.0": {"linux": "sha256-linux", "freebsd": ""}}`, h6) == outdent(`
         {
@@ -215,6 +216,7 @@ unittest {
 }
 
 // editorconfig-checker-disable
+@("dlang_nix.utils.json.toSortedPrettyJson")
 unittest {
     import std.json : parseJSON;
 

--- a/src/main.d
+++ b/src/main.d
@@ -14,6 +14,7 @@ import std.typecons : tuple;
 import dlang_nix.utils.commands : prefech, Hash, resolveVersionRange, resolveTagRevs;
 import dlang_nix.utils.json : hashesToJsonValue, mergeHashesIntoJson, toSortedPrettyJson;
 import dlang_nix.components : Platform, Families, familyPinsRev;
+import dlang_nix.ci.cli : runCi;
 
 /// `name1 | name2 | …` over every family — the allowed `--component` tokens.
 string componentNames() {
@@ -131,6 +132,13 @@ void runFetch(F)(string[] versionStrs, string firstVersion, string lastVersion, 
 }
 
 void main(string[] args) {
+    // `ci` subcommand: CI build-matrix helpers (see dlang_nix.ci.cli). Anything
+    // else falls through to the default release-prefetcher below.
+    if (args.length >= 2 && args[1] == "ci") {
+        runCi(args[1 .. $]);
+        return;
+    }
+
     string[] componentVersions;
     string component = "ldc-binary";
     bool liveRun = false;

--- a/src/main.d
+++ b/src/main.d
@@ -1,25 +1,138 @@
 import std.algorithm : joiner, map, uniq;
-import std.array : array;
+import std.array : array, join;
+import std.conv : to;
 import std.exception : enforce;
 static import std.file;
-import std.format : format;
 import std.functional : adjoin;
 import std.getopt : getopt, GetOptException, defaultGetoptFormatter;
 static import std.getopt;
 import std.parallelism : parallel;
-import std.path : buildNormalizedPath, dirName;
 import std.range : iota, walkLength;
 import std.stdio : stdout, stderr;
-import std.string : strip;
 import std.typecons : tuple;
 
-import dlang_nix.utils.commands : prefech, Hash;
+import dlang_nix.utils.commands : prefech, Hash, resolveVersionRange, resolveTagRevs;
 import dlang_nix.utils.json : hashesToJsonValue, mergeHashesIntoJson, toSortedPrettyJson;
-import dlang_nix.components : Platform, Version, Component, supportedPlatforms, ComponentInfo;
+import dlang_nix.components : Platform, Families, familyPinsRev;
+
+/// `name1 | name2 | …` over every family — the allowed `--component` tokens.
+string componentNames() {
+    string[] names;
+    static foreach (F; Families)
+        names ~= F.name;
+    return names.join(" | ");
+}
+
+/// Prefetches the requested versions of family `F` and writes/prints the
+/// `version -> platform -> hash` table. The version pipeline is typed on
+/// `F.VersionType`; `string` appears only at the CLI and JSON boundaries.
+void runFetch(F)(string[] versionStrs, string firstVersion, string lastVersion, bool liveRun) {
+    alias V = F.VersionType;
+
+    V[] versions;
+    if (firstVersion.length > 0 || lastVersion.length > 0) {
+        enforce(firstVersion.length > 0,
+            "--last-version requires --first-version.");
+        enforce(versionStrs.length == 0,
+            "--versions is mutually exclusive with " ~
+                "--first-version/--last-version.");
+
+        stderr.writefln(
+            "Resolving %s..%s (repo: %s)...",
+            firstVersion,
+            lastVersion.length > 0 ? lastVersion : "latest",
+            F.tagsRepo);
+
+        versions = resolveVersionRange!V(F.tagsRepo, firstVersion, lastVersion);
+        enforce(versions.length > 0,
+            "No stable releases found in range " ~
+                firstVersion ~ ".." ~
+                (lastVersion.length > 0 ? lastVersion : "latest"));
+        stderr.writefln("Resolved to %s versions: %-(%s, %)",
+            versions.length, versions);
+    }
+    else
+        versions = versionStrs.length
+            ? versionStrs.map!(s => V.parseLoose(s).value).array
+            : F.defaultVersions;
+
+    // Pin the commit each release tag points to, for families whose nix
+    // fetcher takes an explicit `rev` (optional capability).
+    Hash[string] revs;
+    static if (familyPinsRev!F)
+        revs = resolveTagRevs!V(F.tagsRepo, versions);
+
+    const platforms = versions
+        .map!(v => F.platforms(v))
+        .uniq
+        .adjoin!(
+            versArrays => enforce(versArrays.walkLength(2) == 1,
+                "Requested versions differ in set of platforms they support. " ~
+                "Please specify a set of versions with a common set of " ~
+                "supported platforms."),
+            versArrays => versArrays.front
+        )[1];
+
+    foreach (v; versions)
+        stderr.writefln(
+            "* Prefetching %s v%s for %s:",
+            F.name,
+            v,
+            platforms,
+        );
+    stderr.writeln("-----");
+
+    auto jobs = versions.map!(v =>
+        platforms.map!(platform =>
+            tuple(v, platform, F.url(platform, v), F.unpackingNeed)
+        ).array
+    ).joiner.array;
+
+    // Fetch in parallel into a pre-allocated array (thread-safe:
+    // each index is written by exactly one worker).
+    auto results = new Hash[](jobs.length);
+
+    foreach (i; iota(jobs.length).parallel) {
+        results[i] = prefech(!liveRun, jobs[i][2], jobs[i][3]);
+    }
+
+    // Build hashes AA from results (single-threaded). Keyed by the version's
+    // canonical string at the serialization boundary.
+    Hash[Platform][string] hashes;
+    foreach (i; 0 .. jobs.length) {
+        hashes[jobs[i][0].to!string][jobs[i][1]] = results[i];
+    }
+    foreach (ver, rev; revs) {
+        hashes[ver]["rev"] = rev;
+    }
+
+    if (!liveRun) {
+        stderr.writeln("-----");
+        stderr.writeln("Fetching was not performed, this was a dry run.");
+    }
+
+    if (liveRun) {
+        const target = F.supportedVersionsFile;
+        const existingJson =
+            std.file.exists(target) ? std.file.readText(target) : "";
+        const merged = mergeHashesIntoJson(existingJson, hashes);
+        const tmpFile = target ~ ".tmp";
+        std.file.write(tmpFile, merged);
+        std.file.rename(tmpFile, target);
+        stderr.writefln("Updated %s", target);
+    }
+
+    stderr.writeln("-----");
+    stderr.writeln("All done!\n");
+
+    stdout.writeln(
+        toSortedPrettyJson(hashesToJsonValue(hashes))
+    );
+}
 
 void main(string[] args) {
-    Version[] componentVersions;
-    Component component = Component.ldc;
+    string[] componentVersions;
+    string component = "ldc-binary";
     bool liveRun = false;
     string firstVersion, lastVersion;
 
@@ -40,10 +153,8 @@ void main(string[] args) {
                     "tag available in the repo.",
                 &lastVersion,
             "component",
-                // Ideally we would generate the list of allowed values as
-                // opposed to this hardcoding
-                "What component to fetch. dmd | dmd_src | ldc | ldc_src | dub, " ~
-                    "default ldc",
+                "What component to fetch. " ~ componentNames() ~
+                    ", default ldc-binary",
                 &component,
             "dry-run",
                 "Only print what would be done, but don't really act." ~
@@ -74,111 +185,12 @@ void main(string[] args) {
         return;
     }
 
-    const compilerInfo = supportedPlatforms[component];
-
-    // Resolve --first-version/--last-version into an explicit version list.
-    if (firstVersion.length > 0 || lastVersion.length > 0) {
-        enforce(firstVersion.length > 0,
-            "--last-version requires --first-version.");
-        enforce(componentVersions.length == 0,
-            "--versions is mutually exclusive with " ~
-                "--first-version/--last-version.");
-
-        stderr.writefln(
-            "Resolving %s..%s (repo: %s)...",
-            firstVersion,
-            lastVersion.length > 0 ? lastVersion : "latest",
-            compilerInfo.tagsRepo);
-
-        componentVersions = compilerInfo.resolveVersions(
-            compilerInfo.tagsRepo, firstVersion, lastVersion);
-        enforce(componentVersions.length > 0,
-            "No stable releases found in range " ~
-                firstVersion ~ ".." ~
-                (lastVersion.length > 0 ? lastVersion : "latest"));
-        stderr.writefln("Resolved to %s versions: %-(%s, %)",
-            componentVersions.length, componentVersions);
-    }
-    else
-    {
-        componentVersions = componentVersions.length
-            ? componentVersions
-            : compilerInfo.defaultVersions.dup;
-    }
-
-    // Pin the commit each release tag points to, for components whose nix
-    // fetcher takes an explicit `rev` alongside the hash.
-    Hash[Version] revs;
-    if (compilerInfo.resolveRevs !is null)
-        revs = compilerInfo.resolveRevs(
-            compilerInfo.tagsRepo, componentVersions);
-
-    const platforms = componentVersions
-        .map!(vers => compilerInfo.platforms(vers))
-        .uniq
-        .adjoin!(
-            versArrays => enforce(versArrays.walkLength(2) == 1,
-                "Requested versions differ in set of platforms they support. " ~
-                "Please specify a set of versions with a common set of " ~
-                "supported platforms."),
-            versArrays => versArrays.front
-        )[1];
-
-    const getUrl = compilerInfo.urlFormatter;
-
-    foreach (compilerVersion; componentVersions)
-        stderr.writefln(
-            "* Prefetching %s v%s for %s:",
-            component,
-            compilerVersion,
-            platforms,
-        );
-    stderr.writeln("-----");
-
-    auto jobs = componentVersions.map!(compilerVersion =>
-        platforms.map!(platform =>
-            tuple(compilerVersion, platform, getUrl(platform, compilerVersion),
-                compilerInfo.unpackingNeed)
-        ).array
-    ).joiner.array;
-
-    // Fetch in parallel into a pre-allocated array (thread-safe:
-    // each index is written by exactly one worker).
-    auto results = new Hash[](jobs.length);
-
-    foreach (i; iota(jobs.length).parallel) {
-        results[i] = prefech(!liveRun, jobs[i][2], jobs[i][3]);
-    }
-
-    // Build hashes AA from results (single-threaded).
-    Hash[Platform][Version] hashes;
-    foreach (i; 0 .. jobs.length) {
-        hashes[jobs[i][0]][jobs[i][1]] = results[i];
-    }
-    foreach (compilerVersion, rev; revs) {
-        hashes[compilerVersion]["rev"] = rev;
-    }
-
-    if (!liveRun) {
-        stderr.writeln("-----");
-        stderr.writeln("Fetching was not performed, this was a dry run.");
-    }
-
-    if (liveRun) {
-        const target = supportedPlatforms[component].supportedVersionsFile;
-        const existingJson =
-            std.file.exists(target) ? std.file.readText(target) : "";
-        const merged = mergeHashesIntoJson(existingJson, hashes);
-        const tmpFile = target ~ ".tmp";
-        std.file.write(tmpFile, merged);
-        std.file.rename(tmpFile, target);
-        stderr.writefln("Updated %s", target);
-    }
-
-    stderr.writeln("-----");
-    stderr.writeln("All done!\n");
-
-    stdout.writeln(
-        toSortedPrettyJson(hashesToJsonValue(hashes))
-    );
+    // Dispatch the runtime `--component` token to its compile-time family.
+    static foreach (F; Families)
+        if (component == F.name) {
+            runFetch!F(componentVersions, firstVersion, lastVersion, liveRun);
+            return;
+        }
+    enforce(false,
+        "unknown --component '" ~ component ~ "'; expected one of: " ~ componentNames());
 }


### PR DESCRIPTION
Packs the GitHub Actions `build` matrix by estimated build time so it stays
under GitHub's hard **256-configuration-per-matrix** cap.

## Problem
The `build` job emits one matrix entry per uncached, buildable `(package,
system)`. Cold-cache that is **354** configs — over the limit, so the workflow
errors before building anything.

## Approach
A `ci` subcommand on the `dlang-nix-fetcher` D tool packs packages into far
fewer jobs (~110) by relative build weight: heavy compiler builds (`ldc`/`dmd`
source) get dedicated jobs, cheap ones (binaries, build-only `dub`) are batched
(First-Fit-Decreasing, capacity = the longest single build). Per-package status
is still surfaced in the sticky PR comment.

- `ci plan-matrix` — packs the matrix; pure, unit-tested logic in
  `src/dlang_nix/ci/weights.d`.
- `ci calibrate` — measures real per-`(system, family, tests)` build times →
  `scripts/ci-build-weights.json`.
- `lib.doCheckMap` — the tests-enabled signal used for weighting.
- Packaged at `pkgs/dlang-nix-fetcher`, added to the `.#ci` dev shell.

## Notes
- Weights are real measurements (x86_64-linux locally; darwin via a remote
  builder, x86_64-darwin through Rosetta 2).
- The nixpkgs-upgrade work (#225) is **stacked on top of this PR**.
