### PR TITLE
chore: set meta.mainProgram for all packages

### DIFF
--- a/pkgs/dmd/binary.nix
+++ b/pkgs/dmd/binary.nix
@@ -79,5 +79,6 @@ stdenv.mkDerivation {
       "i686-linux"
       "x86_64-linux"
     ];
+    mainProgram = "dmd";
   };
 }

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -489,5 +489,6 @@ stdenv.mkDerivation rec {
       "i686-linux"
       "x86_64-darwin"
     ];
+    mainProgram = "dmd";
   };
 }

--- a/pkgs/dub/default.nix
+++ b/pkgs/dub/default.nix
@@ -103,5 +103,6 @@ stdenv.mkDerivation rec {
       "x86_64-darwin"
       "aarch64-darwin"
     ];
+    mainProgram = "dub";
   };
 }

--- a/pkgs/ldc/binary.nix
+++ b/pkgs/ldc/binary.nix
@@ -99,5 +99,6 @@ stdenv.mkDerivation {
       lionello
     ];
     platforms = supportedSystems;
+    mainProgram = "ldc2";
   };
 }


### PR DESCRIPTION
Sets the `meta.mainProgram` attribute on the remaining packages so that it is properly populated for dmd, dmd-binary, dub, and ldc-binary.