### PR TITLE
dcd: drop leaveDotGit to make the source FOD reproducible

### DIFF
--- a/pkgs/dcd/default.nix
+++ b/pkgs/dcd/default.nix
@@ -19,8 +19,12 @@ in
       owner = "dlang-community";
       repo = "DCD";
       rev = "v${version}";
-      hash = "sha256-3OWTnvDDiUnF8mVM98uUqYqLAJwI4AH+CN5C8WCPDOs=";
-      leaveDotGit = true;
+      # NOTE: do not set `leaveDotGit` here. It makes this fixed-output
+      # derivation non-reproducible (the packed `.git` content depends on the
+      # git-server's behaviour), so the pinned hash drifts and breaks the build.
+      # The build does not need `.git`: it stubs `git` (fakeGit) and seds out
+      # `git describe --tags` in preBuild.
+      hash = "sha256-c5PAUjS2+DvY1QfI+whu0bqFQl0wDUzUUtfHjRFoieA=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
## Summary

Drop `leaveDotGit = true` from DCD's source fetch so the fixed-output derivation (FOD) is reproducible. With `leaveDotGit`, the build breaks on any machine that doesn't already have the old source output in its store — which is every clean CI runner.

## Symptom

`nix build .#dcd` (and anything depending on it via `buildDubPackage`) fails with:

```
error: hash mismatch in fixed-output derivation '/nix/store/87hm5ig3fr5jd8jqy5d95ggf8byh1pjg-source.drv':
         specified: sha256-3OWTnvDDiUnF8mVM98uUqYqLAJwI4AH+CN5C8WCPDOs=
            got:    sha256-9F0wHHcCS/ZofoRy8IqtID1sNra+oKAYenAZMii/QsM=
```

## Root cause: `leaveDotGit` is non-reproducible by construction

`fetchFromGitHub { leaveDotGit = true; }` keeps the `.git` directory inside the FOD output. The bytes of that `.git` directory are **not** a pure function of the source revision — they depend on:

- the **git server's** wire/packing behaviour (GitHub has changed this over time),
- the **git client version** doing the clone (packing, ref layout, `gc` heuristics),
- timestamps/ordering that aren't fully normalised.

So the NAR hash of a `leaveDotGit` fetch is inherently unstable across time and across machines, even for a fixed `rev`. The hash pinned here (`sha256-3OWTnvDD…`) was computed under one set of conditions; the bytes GitHub serves today produce `sha256-9F0wHHcC…`, and the pin no longer matches.

## Why it appeared to work for a long time, then suddenly broke

A FOD is content-addressed by its **output** hash. As long as **any** machine had previously built the `sha256-3OWTnvDD…` output and it was reachable (local store or a binary cache), Nix substituted that output and **never re-ran the fetch** — so the broken fetch was never exercised and everything looked green. The moment that output was no longer available to a builder (fresh CI runner, GC'd store, or a binary cache that stopped serving it), Nix had to **re-realise** the FOD, re-fetched from GitHub, got the drifted `.git` bytes, and the hash mismatch surfaced. In other words: the bug was latent and masked by caching; it didn't "newly break", the cache that hid it went away.

## Why `overrideAttrs` downstream can't paper over it

Consumers can't fix this with `dcd.overrideAttrs (_: { src = …; })`. `buildDubPackage` consumes the **original** `src` at **evaluation time** via import-from-derivation:

```nix
# pkgs/build-dub-package/default.nix
if builtins.pathExists "${src}/dub.selections.json"
then "${src}/dub.selections.json"
…
then (builtins.fromJSON (builtins.readFile selectionsJson)).versions
```

`pathExists`/`readFile` on `"${src}/…"` force **realising the original `src`** during eval, before `overrideAttrs` replaces the final derivation's `src`. So the broken `leaveDotGit` source is fetched regardless of any downstream override. The fix has to live here, on the source the derivation is built from.

## The fix is safe because the build never needs `.git`

DCD's recipe already avoids needing git history at build time:

- it injects a `fakeGit` stub (`writeShellScriptBin "git"`),
- and `preBuild` rewrites the makefile: `sed -i 's/git describe --tags/echo v${version}/' makefile`.

So `.git` is dead weight. Dropping `leaveDotGit` and fetching just the worktree (`fetchSubmodules = true` is still required for `msgpack-d`/`libdparse`/`dsymbol`/`containers`) yields a source tree that is content-addressed by the **files**, which is stable and immune to git-server/client drift.

New hash: `sha256-c5PAUjS2+DvY1QfI+whu0bqFQl0wDUzUUtfHjRFoieA=`.

## Verification

`nix build .#dcd` on `x86_64-linux` builds `dcd-0.15.2` end-to-end from a clean fetch (the deterministic `…-source` FOD builds with no hash mismatch, then `dcd-0.15.2` links and installs `dcd-client`/`dcd-server`).

## Note for maintainers

`metacraft-labs/nixos-modules` consumes this branch and is temporarily pointing its `dlang-nix` input at a fork carrying this commit. Once this lands we'll switch the input back to upstream. Happy to adjust the approach (e.g. pin a specific `rev` instead of dropping `leaveDotGit`) if you prefer, but dropping `leaveDotGit` is the only option that's reproducible across machines.
