### PR TITLE
fix(pkgs/dmd): strip host bootstrap compiler from runtime closure

### DIFF
--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -33,6 +33,7 @@
   git,
   unzip,
   darwinMinVersionHook,
+  removeReferencesTo,
   hostDCompiler,
 }:
 let
@@ -474,6 +475,20 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  # `dmd` is bootstrapped with `hostDCompiler` (an LDC, e.g. ldc-binary), whose
+  # druntime/phobos are *statically* linked into the resulting compiler binary.
+  # The machine code is copied in, so the bootstrap is not needed at runtime
+  # (empty rpath, no DT_NEEDED on it), but dead path strings to it survive in
+  # the binary and keep the entire host compiler (~480 MiB) in dmd's runtime
+  # closure. Scrub those references, mirroring nixpkgs' upstream dmd, so dmd
+  # consumers don't drag the bootstrap compiler around.
+  preFixup = ''
+    find $out/bin -type f -exec ${removeReferencesTo}/bin/remove-references-to \
+      -t ${hostDCompiler} '{}' +
+  '';
+
+  disallowedReferences = [ hostDCompiler ];
 
   meta = with lib; {
     description = "Official reference compiler for the D language";


### PR DESCRIPTION
## Problem

`dmd` is bootstrapped by `hostDCompiler` (an LDC, e.g. `ldc-binary-1_42_0`),
whose druntime/phobos are **statically** linked into the resulting compiler
binary. The machine code is copied in, so the bootstrap compiler is not needed
at runtime — the dmd binary has an empty rpath and no `DT_NEEDED` entry for it —
yet dead store-path strings to the bootstrap survive inside the binary.

Those strings make Nix treat the entire host compiler (~480 MiB) as a runtime
dependency, so it lands in `dmd`'s closure and therefore in **every** dmd
consumer's closure.

## Fix

Scrub the references with `remove-references-to` in `preFixup`, and assert they
are gone via `disallowedReferences` — exactly the approach the upstream nixpkgs
`dmd` package uses.

## Result (dmd 2.112.1, x86_64-linux)

| | closure | store paths | `ldc-binary` in closure |
| --- | --- | --- | --- |
| before | 968 MiB | 66 | yes |
| after | **488 MiB** | **42** | no |

`dmd --version` works, a downstream example builds, and the package's own test
suite (`doCheck`) still passes.

https://claude.ai/code/session_012HAgTH22facAUpS3fg18rB