### PR TITLE
feat(pkgs/ldc): add ldc-android aarch64 cross-compilation variant

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,9 +6,40 @@ in
   imports = [ inputs.flake-parts.flakeModules.easyOverlay ];
 
   perSystem =
-    { self', pkgs, ... }:
+    {
+      self',
+      pkgs,
+      system,
+      ...
+    }:
     let
       inherit (import ../lib/version-catalog.nix { inherit lib pkgs self'; }) genPkgVersions;
+
+      # Android NDK cross-compilation toolchain. Opt-in and Linux/x86_64-only
+      # (that is the only host the NDK ships prebuilt for here), and it pulls in
+      # the *unfree* Android SDK NDK, so it is kept out of the default package
+      # set and only materialises when `ldc-android` is built explicitly.
+      androidPkgs = import inputs.nixpkgs {
+        inherit system;
+        config = {
+          allowUnfree = true;
+          android_sdk.accept_license = true;
+        };
+      };
+      ndkBundle = (androidPkgs.androidenv.composeAndroidPackages { includeNDK = true; }).ndk-bundle;
+      ndkRoot = "${ndkBundle}/libexec/android-sdk/ndk/${ndkBundle.version}";
+      ldcAndroidRuntime = pkgs.callPackage ./ldc/android-runtime.nix {
+        ldc = self'.packages.ldc;
+        ndk = ndkRoot;
+      };
+      androidPackages = {
+        ldc-android-runtime = ldcAndroidRuntime;
+        ldc-android = pkgs.callPackage ./ldc/android.nix {
+          ldc = self'.packages.ldc;
+          androidRuntime = ldcAndroidRuntime;
+          ndk = ndkRoot;
+        };
+      };
     in
     {
       overlayAttrs = self'.packages;
@@ -18,29 +49,29 @@ in
         // (genPkgVersions "ldc").hierarchical
         // (genPkgVersions "dub").hierarchical;
 
-      packages =
-        {
-          # NOTE: This is only the default. The bootstrap compiler in the
-          # version catalog will override this.
-          ldc-bootstrap = self'.packages."ldc-binary-1_42_0";
-          ldc = self'.packages."ldc-1_42_0";
+      packages = {
+        # NOTE: This is only the default. The bootstrap compiler in the
+        # version catalog will override this.
+        ldc-bootstrap = self'.packages."ldc-binary-1_42_0";
+        ldc = self'.packages."ldc-1_42_0";
 
-          # DUB is released alongside DMD. When DMD 2.112.0 shipped, upstream
-          # appears to have forgotten to bump DUB from 1.42.0-beta.1 to the
-          # final 1.42.0 tag, so the newest released DUB is still this beta.
-          # Switch to "dub-1_42_0" once upstream tags the stable release.
-          dub = self'.packages."dub-1_42_0-beta_1";
+        # DUB is released alongside DMD. When DMD 2.112.0 shipped, upstream
+        # appears to have forgotten to bump DUB from 1.42.0-beta.1 to the
+        # final 1.42.0 tag, so the newest released DUB is still this beta.
+        # Switch to "dub-1_42_0" once upstream tags the stable release.
+        dub = self'.packages."dub-1_42_0-beta_1";
+      }
+      // (genPkgVersions "ldc").flattened "binary"
+      // (genPkgVersions "ldc").flattened "source"
+      // (genPkgVersions "dub").flattened "source"
+      // optionalAttrs pkgs.hostPlatform.isx86 (
+        {
+          dmd-bootstrap = self'.packages."dmd-binary-2_098_0";
+          dmd = self'.packages."dmd-2_112_0";
         }
-        // (genPkgVersions "ldc").flattened "binary"
-        // (genPkgVersions "ldc").flattened "source"
-        // (genPkgVersions "dub").flattened "source"
-        // optionalAttrs pkgs.hostPlatform.isx86 (
-          {
-            dmd-bootstrap = self'.packages."dmd-binary-2_098_0";
-            dmd = self'.packages."dmd-2_112_0";
-          }
-          // (genPkgVersions "dmd").flattened "binary"
-          // (genPkgVersions "dmd").flattened "source"
-        );
+        // (genPkgVersions "dmd").flattened "binary"
+        // (genPkgVersions "dmd").flattened "source"
+      )
+      // optionalAttrs (system == "x86_64-linux") androidPackages;
     };
 }

--- a/pkgs/ldc/android-runtime.nix
+++ b/pkgs/ldc/android-runtime.nix
@@ -1,0 +1,95 @@
+# LDC druntime + phobos cross-built for Android (aarch64), from the same LDC
+# source tarball as the host compiler, using `ldc-build-runtime` driving the
+# NDK's CMake toolchain file. The resulting static libraries are consumed by
+# the `ldc-android` wrapper (see ./android.nix), which registers an
+# `aarch64-.*-linux-android` section in ldc2.conf pointing `lib-dirs` here.
+#
+# Recipe per the LDC "Cross-compiling with LDC" / "Build D for Android" notes:
+#   ldc-build-runtime --ninja \
+#       --dFlags="-mtriple=aarch64--linux-android" \
+#       --targetSystem="Android;Linux;UNIX" \
+#       CMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
+#       ANDROID_ABI=arm64-v8a ANDROID_NATIVE_API_LEVEL=21
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  ldc,
+  # NDK *root* (the directory containing build/cmake/android.toolchain.cmake and
+  # toolchains/llvm/prebuilt/linux-x86_64), not the ndk-bundle store root.
+  ndk,
+  abi ? "arm64-v8a",
+  apiLevel ? "21",
+  # LLVM target triple LDC matches against the `aarch64-.*-linux-android`
+  # config section. The empty vendor field (double dash) matches upstream docs.
+  mtriple ? "aarch64--linux-android",
+}:
+
+stdenv.mkDerivation {
+  pname = "ldc-android-runtime-aarch64";
+  inherit (ldc) version;
+
+  # Reuse the exact source the host LDC was built from, so the cross-built
+  # runtime ABI always matches the compiler that links against it.
+  src = ldc.src;
+
+  nativeBuildInputs = [
+    cmake # ldc-build-runtime drives cmake under the hood
+    ninja
+    ldc # provides ldc-build-runtime + the host ldc2 used to codegen the runtime
+  ];
+
+  # ldc-build-runtime does the configure/build itself; skip stdenv's phases.
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export ANDROID_NDK_ROOT=${ndk}
+    export ANDROID_NDK_HOME=${ndk}
+
+    # Static-only: the shared druntime fails to link against bionic
+    # (`__tls_get_addr` undefined in rt/sections_elf_shared), and the Android
+    # cross-compile path links the static runtime anyway
+    # (`-link-defaultlib-shared=false`), so the shared variants are dead weight.
+    ldc-build-runtime --ninja \
+      --ldcSrcDir="$PWD" \
+      --buildDir="$PWD/build-android-aarch64" \
+      --dFlags="-mtriple=${mtriple}" \
+      --targetSystem="Android;Linux;UNIX" \
+      BUILD_SHARED_LIBS=OFF \
+      CMAKE_TOOLCHAIN_FILE=${ndk}/build/cmake/android.toolchain.cmake \
+      ANDROID_ABI=${abi} \
+      ANDROID_NATIVE_API_LEVEL=${apiLevel}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -v build-android-aarch64/lib/*.a $out/lib/ 2>/dev/null || true
+    # Some configurations also emit shared objects; ship them if present.
+    cp -v build-android-aarch64/lib/*.so $out/lib/ 2>/dev/null || true
+
+    if [ -z "$(ls -A $out/lib)" ]; then
+      echo "error: no runtime libraries produced in build-android-aarch64/lib" >&2
+      find build-android-aarch64 -name '*.a' -o -name '*.so' >&2 || true
+      exit 1
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "LDC druntime + phobos cross-built for Android aarch64";
+    homepage = "https://github.com/ldc-developers/ldc";
+    license = with licenses; [
+      bsd3
+      boost
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/ldc/android.nix
+++ b/pkgs/ldc/android.nix
@@ -1,0 +1,82 @@
+# `ldc-android`: the host LDC, taught to cross-compile for Android aarch64.
+#
+# It wraps the normal (host) `ldc2`/`ldmd2` with a `-conf=` override pointing at
+# a config that is the host config plus an extra section matching the Android
+# triple. That section links against the cross-built runtime (./android-runtime.nix)
+# and uses the NDK clang as LDC's C compiler / linker driver (`-gcc`).
+#
+# Usage once on PATH (see the opt-in devShell in the sparkles repo):
+#   ldc2 -mtriple=aarch64--linux-android --shared app.d c.c \
+#        -L-llog -L-landroid -of=libapp.so
+#
+# We follow the repo's established Darwin-wrapper idiom (symlinkJoin + wrapProgram
+# with `-conf=`) rather than mutating the read-only config directory: the result
+# stays a *complete* ldc (its `lib/`, `ldmd2`, etc. are untouched) and only the
+# two drivers gain the extra `-conf` flag.
+{
+  lib,
+  symlinkJoin,
+  makeWrapper,
+  runCommand,
+  ldc,
+  # Cross-built druntime/phobos for aarch64 Android (./android-runtime.nix).
+  androidRuntime,
+  # NDK root (dir containing toolchains/llvm/prebuilt/linux-x86_64).
+  ndk,
+  apiLevel ? "21",
+}:
+
+let
+  ndkClang = "${ndk}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${apiLevel}-clang";
+
+  # The Android section appended after the host sections. `~=` appends to the
+  # default switches; `lib-dirs`/`rpath` are overwritten so the host runtime is
+  # never searched for an Android link. `-link-defaultlib-shared=false` selects
+  # the static druntime/phobos archives shipped by androidRuntime.
+  androidSection = ''
+
+    // ---- added by dlang.nix ldc-android (cross-compile to Android aarch64) ----
+    "aarch64-.*-linux-android":
+    {
+        switches ~= [
+            "-defaultlib=phobos2-ldc,druntime-ldc",
+            "-link-defaultlib-shared=false",
+            "-gcc=${ndkClang}",
+        ];
+        lib-dirs = [
+            "${androidRuntime}/lib",
+        ];
+        rpath = "";
+    };
+  '';
+
+  # LDC's directory-based config is read by concatenating its `*.conf` files in
+  # natural order; `-conf=<file>` instead reads a single file. We reproduce the
+  # directory by concatenating the host drop-ins (in glob/lexical order, which
+  # matches LDC's numeric ordering) and appending the Android section.
+  mergedConf = runCommand "ldc2-android.conf" { } ''
+    cat ${ldc}/etc/ldc2.conf/*.conf > $out
+    cat >> $out <<'LDC_ANDROID_EOF'
+    ${androidSection}
+    LDC_ANDROID_EOF
+  '';
+in
+symlinkJoin {
+  name = "ldc-android-${ldc.version}";
+  paths = [ ldc ];
+  nativeBuildInputs = [ makeWrapper ];
+  postBuild = ''
+    for drv in ldc2 ldmd2; do
+      wrapProgram "$out/bin/$drv" --add-flags "-conf=${mergedConf}"
+    done
+  '';
+  passthru = {
+    inherit androidRuntime mergedConf;
+    ndkRoot = ndk;
+  };
+  meta = ldc.meta // {
+    description = "LDC configured to cross-compile for Android aarch64";
+    mainProgram = "ldc2";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## What

Adds an opt-in `ldc-android` package that teaches the host LDC to cross-compile for Android aarch64, plus the `ldc-android-runtime` derivation it links against.

## Changes

- `pkgs/ldc/android-runtime.nix`: cross-builds druntime + phobos from the same LDC source tarball as the host compiler, via `ldc-build-runtime` driving the NDK CMake toolchain file (`-mtriple=aarch64--linux-android`, ABI arm64-v8a, API level 21). Static-only (`BUILD_SHARED_LIBS=OFF`): the shared druntime fails to link against bionic (`__tls_get_addr`), and the Android link path uses the static runtime anyway.
- `pkgs/ldc/android.nix`: wraps the host `ldc2`/`ldmd2` (symlinkJoin + `-conf=` override, matching the repo's Darwin-wrapper idiom) with an extra `aarch64-.*-linux-android` ldc2.conf section pointing `-gcc` at the NDK clang and `lib-dirs` at the cross-built runtime.
- `pkgs/default.nix`: exposes `ldc-android` / `ldc-android-runtime` on x86_64-linux only. The NDK comes from nixpkgs `androidenv` re-imported with the unfree Android licence accepted, scoped so the default package set stays free and these only materialise when built explicitly.

## Usage

```bash
ldc2 -mtriple=aarch64--linux-android --shared app.d c.c \
     -L-llog -L-landroid -of=libapp.so
```

## Overlap with other branches

This is the smallest Android slice. Two other open PRs **rewrite the same android commit** rather than stacking on this SHA:

- **wasm / i686 / dual-ABI Android** (`feat/ldc-wasm`) — supersedes this with aarch64 + x86_64 Android, wasm32-wasip2, and i686-linux.
- **Windows MSVC libs** (`feat/ldc-windows-cross-libs`) — includes this android commit plus `ldc-binary-windows-libs`.

Do **not** merge this together with those without restacking. If the larger wasm PR is preferred, this PR can be closed as superseded.

## Verification

`ldc2 -mtriple=aarch64--linux-android -shared` produces a valid ELF aarch64 shared object.